### PR TITLE
SREP-2239: Add Subscription validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ A Flask app designed to act as a webhook admission controller for OpenShift.
 
 Presently there is a single webhook, [group-validation](#group_validation), which is provided via `/group-validation` endpoint.
 
-## Group Validation
+## Webhooks
+
+### Group Validation
 
 Configuration for this webhook is provided by environment variables:
 
 * `GROUP_VALIDATION_PREFIX` - Group prefix to apply the webhook, such as `osd-` to apply to `CREATE`, `UPDATE`, `DELETE` operations on groups starting with `osd-`.
 * `GROUP_VALIDATION_ADMIN_GROUP` - Admin group, which the requestor must be a member in order to have access granted.
 * `DEBUG_GROUP_VALIDATION` - Debug the webhook? Set to `True` to enable, all other values (including absent) disable.
+
+### Subscription Validation
+
+Restrict dedicated-admins to creating `Subscription` objects with `.spec.sourceNamespace` from a pre-approved list. The list is specified by environment variable:
+
+* `SUBSCRIPTION_VALIDATION_NAMESPACES` - Comma-separated list of namespaces for which dedicated-admins are allowed to use as `.spec.sourceNamespace` in `Subscription` objects. (default "openshift-operators")
+* `DEBUG_SUBSCRIPTION_VALIDATION` - Debug the hook (not currently used)
 
 ## How it works
 

--- a/src/gunicorn.py
+++ b/src/gunicorn.py
@@ -1,14 +1,9 @@
 # gunicorn config file
-import ssl
 
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "pid=%(p)s"'
 raw_env = [
   'FLASK_APP=webhook',
-
-  'GROUP_VALIDATION_ADMIN_GROUP=osd-sre-admins',
-  'GROUP_VALIDATION_PREFIX=osd-sre-',
 ]
 bind="0.0.0.0:5000"
 workers=5
 accesslog="-"
-#cert_reqs = ssl.CERT_REQUIRED

--- a/src/webhook/__init__.py
+++ b/src/webhook/__init__.py
@@ -5,3 +5,6 @@ app = Flask(__name__,instance_relative_config=True)
 
 from webhook import group_validation
 app.register_blueprint(group_validation.bp)
+
+from webhook import subscription_validation
+app.register_blueprint(subscription_validation.bp)

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -1,48 +1,36 @@
 from flask import request, Blueprint
+import sys, traceback
 import json
 import os
 
 from webhook.request_helper import validate, responses
 
-bp = Blueprint("webhook", __name__)
+bp = Blueprint("group-webhook", __name__)
 
-group_prefix = os.getenv("GROUP_VALIDATION_PREFIX")
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP")
+group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
+admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins")
 
-configok = True
+@bp.route('/group-validation', methods=('GET','POST'))
+def handle_request():
+  debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
+  debug = (debug == "True")
 
-if group_prefix is None:
-  print("Please specify the group prefix with GROUP_VALIDATION_PREFIX environment variable. Refusing to expose /group-validation webhook.")
-  configok = False
+  if debug:
+    print("REQUEST BODY => {}".format(request.json))
 
-if admin_group is None:
-  print("Please specify the admin group with the GROUP_VALIDATION_ADMIN_GROUP environment variable. Refusing to expose /group-validation webhook.")
-  configok = False
+  valid = True
+  try:
+    valid = validate.validate_request_structure(request.json)
+  except:
+    valid = False
 
-if configok:
-  @bp.route('/group-validation', methods=('GET','POST'))
-  def handle_request():
-    debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
-    debug = (debug == "True")
+  if not valid:
+    return responses.response_invalid()
 
-    valid = True
-    try:
-      valid = validate.validate_request_structure(request.json)
-    except:
-      # if anything goes wrong, it's not valid.
-      valid = False
-
-    if not valid:
-      return responses.response_invalid()
-
+  try:
     body_dict = request.json['request']
     group_name = body_dict['object']['metadata']['name']
     userinfo = body_dict['userInfo']
-
-    if debug:
-      print("REQUEST BODY => {}".format(body_dict))
-      print("Performing action: {} in {} group".format(body_dict['operation'],group_name))
-
     if group_name.startswith(group_prefix):
       if debug:
         print("Performing action: {} in {} group".format(body_dict['operation'],group_name))
@@ -56,3 +44,9 @@ if configok:
     if debug:
       print("Response body => {}".format(response_body))
     return response_body
+  except Exception:
+    print("Exception when trying to access attributes. Request body: {}".format(request.json))
+    print("Backtrace:")
+    print("-"*60)
+    traceback.print_exc(file=sys.stdout)
+    return responses.response_invalid()

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -10,7 +10,7 @@ bp = Blueprint("group-webhook", __name__)
 group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
 admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins")
 
-@bp.route('/group-validation', methods=('GET','POST'))
+@bp.route('/group-validation', methods=('POST'))
 def handle_request():
   debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
   debug = (debug == "True")

--- a/src/webhook/request_helper/validate.py
+++ b/src/webhook/request_helper/validate.py
@@ -1,40 +1,11 @@
 def validate_request_structure(request_json):
   """Validate the request structure.
   """
-  valid = True
 
   doc_keys = request_json.keys()
 
-  valid = valid & ("request" in doc_keys)
-  request_keys = request_json['request'].keys()
-  valid = valid & ("kind" in request_keys)
-  valid = valid & ("resource" in request_keys)
-  valid = valid & ("operation" in request_keys)
-  valid = valid & ("object" in request_keys)
-
-  user_keys = request_json['request']['userInfo'].keys()
-  valid = valid & ("username" in user_keys)
-  valid = valid & ("groups" in user_keys  )
-  valid = valid & (type(request_json['request']['userInfo']['groups']) is list)
-  valid = valid & ("extra" in user_keys)
-
-  object_keys = request_json['request']['object'].keys()
-  valid = valid & ("metadata" in object_keys)
-  valid = valid & ("users" in object_keys)
-
-  metadata_keys = request_json['request']['object']['metadata'].keys()
-  valid = valid & ("name" in metadata_keys)
-  valid = valid & ("creationTimestamp" in metadata_keys)
-  valid = valid & ("uid" in metadata_keys)
-
-  resource_keys = request_json['request']['resource'].keys()
-  valid = valid & ("group" in resource_keys)
-  valid = valid & ("version" in resource_keys)
-  valid = valid & ("resource" in resource_keys)
-
-  kind_keys = request_json['request']['kind'].keys()
-  valid = valid & ("group" in kind_keys)
-  valid = valid & ("version" in kind_keys)
-  valid = valid & ("kind" in kind_keys)
-
-  return valid
+  if 'kind' not in doc_keys:
+    return False
+  if request_json['kind'] == "AdmissionReview":
+    return True
+  return False

--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -1,0 +1,45 @@
+from flask import request, Blueprint
+import sys, traceback
+import json
+import os
+
+from webhook.request_helper import validate, responses
+
+bp = Blueprint("subscription-webhook", __name__)
+
+valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-operators")
+
+valid_source_namespaces = valid_source_namespaces.split(",")
+
+@bp.route('/subscription-validation', methods=('GET','POST'))
+def handle_request():
+  debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
+  debug = (debug == "True")
+
+  if debug:
+    print("REQUEST BODY => {}".format(request.json))
+
+  valid = True
+  try:
+    valid = validate.validate_request_structure(request.json)
+  except Exception:
+    valid = False
+
+  if not valid:
+    return responses.response_invalid()
+  
+  try:
+    body_dict = request.json['request']
+    requester_group_memberships = body_dict['userInfo']['groups']
+    if "dedicated-admins" in requester_group_memberships:
+      if body_dict['object']['spec']['sourceNamespace'] not in valid_source_namespaces:
+        return responses.response_deny(req=body_dict, msg="You cannot manage Subscriptions that target {}.".format(body_dict['object']['spec']['sourceNamespace']))
+      else:
+        return responses.response_allow(req=body_dict)
+    else:
+      return responses.response_allow(req=body_dict)
+  except Exception:
+    print("Exception:")
+    print("-"*60)
+    traceback.print_exc(file=sys.stdout)
+    return responses.response_invalid()

--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -11,7 +11,7 @@ valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "opens
 
 valid_source_namespaces = valid_source_namespaces.split(",")
 
-@bp.route('/subscription-validation', methods=('GET','POST'))
+@bp.route('/subscription-validation', methods=('POST'))
 def handle_request():
   debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
   debug = (debug == "True")

--- a/templates/10-subscription-validation.ValidatingWebhookConfiguration.yaml.tmpl
+++ b/templates/10-subscription-validation.ValidatingWebhookConfiguration.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata: 
-  name: sre-group-validation
+  name: sre-subscription-validation
   annotations:
     # Typically  managed.openshift.io/inject-cabundle-from: namespace/configmap
     # The configmap must have the cert in PEM format in a key named service-ca.crt.
@@ -12,19 +12,18 @@ webhooks:
       service:
         namespace: #NAMESPACE#
         name: #SVCNAME#
-        path: /group-validation
+        path: /subscription-validation
     failurePolicy:
       "Fail"
-    name: group-validation.managed.openshift.io
+    name: subscription-validation.managed.openshift.io
     rules: 
       - operations: 
           - "UPDATE"
           - "CREATE"
-          - "DELETE"
         apiGroups: 
-          - "user.openshift.io"
+          - "operators.coreos.com"
         apiVersions: 
           - "*"
         resources: 
-          - "groups"
-        scope: "Cluster"
+          - "subscriptions"
+        scope: "Namespaced"

--- a/templates/20-validation-webhook.deployment.yaml.tmpl
+++ b/templates/20-validation-webhook.deployment.yaml.tmpl
@@ -45,8 +45,6 @@ spec:
         - /service-certs/tls.crt
         - --access-logfile
         - "-"
-        - --log-level
-        - debug
         - webhook:app
         name: validation-webhook
         ports:

--- a/templates/20-validation-webhook.deployment.yaml.tmpl
+++ b/templates/20-validation-webhook.deployment.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
   name: #SVCNAME#
   namespace: #NAMESPACE#
 spec:
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       creationTimestamp: null

--- a/templates/20-validation-webhook.deployment.yaml.tmpl
+++ b/templates/20-validation-webhook.deployment.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
   name: #SVCNAME#
   namespace: #NAMESPACE#
 spec:
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       creationTimestamp: null
@@ -26,6 +26,13 @@ spec:
       containers:
       - image: #IMG#:#IMAGETAG#
         imagePullPolicy: Always
+        env:
+        - name: SUBSCRIPTION_VALIDATION_NAMESPACES
+          value: "openshift-operators"
+        - name: GROUP_VALIDATION_ADMIN_GROUP
+          value: "osd-sre-admins"
+        - name: GROUP_VALIDATION_PREFIX
+          value: "osd-sre-"
         command: 
         - gunicorn
         - --config
@@ -38,6 +45,8 @@ spec:
         - /service-certs/tls.crt
         - --access-logfile
         - "-"
+        - --log-level
+        - debug
         - webhook:app
         name: validation-webhook
         ports:


### PR DESCRIPTION
This changeset adds a validation webhook using the same pattern as in #1
which will constrain dedicated-admins to making `Subscription` objects
whose `.spec.sourceNamespace` is defined in a comma-separated list from
the `SUBSCRIPTION_VALIDATION_N    AMESPACES` environment variable (By
default it is only the `openshift-operators` namespace whic is a
permitted `.spec.sourceNamespace` for dedicated-admins).

This changeset also makes some other structural changes:

* Move the environment variables relating to the webhooks out of the
gunicorn.py and into the `Deployment` spec (so that it makes more sense)
* Fundamental changes to the structure of the validation library so that
it is now only looking for the basic structure of the AdmissionReview
(does it have a `kind`? Is it `AdmissionReview`). This ripples on into
the validator hooks as they now ought to use try/except blocks to
account for missing elements in the incoming document.
* Changes the group validator to use the above try/except, and to use sensible
defaults for the two inputs it needs (group prefix, and admin group).
Both can still be overridden by environment variables.

To test the Subscription check, these two documents will put the code
through its paces:

Should fail:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: should-fail
  namespace: myns
spec:
  channel: stable
  name: should-fail
  source: should-fail
  sourceNamespace: default
```

Should pass:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: should-pass
  namespace: myns
spec:
  channel: stable
  name: should-pass
  source: should-pass
  sourceNamespace: openshift-operators
```

Signed-off-by: Lisa Seelye <lseelye@redhat.com>