### PR TITLE
Fix broken HTTP methods declaration

### DIFF
--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -10,7 +10,7 @@ bp = Blueprint("group-webhook", __name__)
 group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
 admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins")
 
-@bp.route('/group-validation', methods=('POST'))
+@bp.route('/group-validation', methods=['POST'])
 def handle_request():
   debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
   debug = (debug == "True")

--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -11,7 +11,7 @@ valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "opens
 
 valid_source_namespaces = valid_source_namespaces.split(",")
 
-@bp.route('/subscription-validation', methods=('POST'))
+@bp.route('/subscription-validation', methods=['POST'])
 def handle_request():
   debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
   debug = (debug == "True")


### PR DESCRIPTION
Moving to only `POST`, but keeping `('POST')` is evidently a syntax
error, so this has been fixed by using `['POST']`.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>