### PR TITLE
SREP-2442: Allow kube:admin to create any group

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Presently there is a single webhook, [group-validation](#group_validation), whic
 
 Configuration for this webhook is provided by environment variables:
 
-* `GROUP_VALIDATION_PREFIX` - Group prefix to apply the webhook, such as `osd-` to apply to `CREATE`, `UPDATE`, `DELETE` operations on groups starting with `osd-`.
-* `GROUP_VALIDATION_ADMIN_GROUP` - Admin group, which the requestor must be a member in order to have access granted.
-* `DEBUG_GROUP_VALIDATION` - Debug the webhook? Set to `True` to enable, all other values (including absent) disable.
+* `GROUP_VALIDATION_PREFIX` - Group prefix to apply the webhook, such as `osd-` to apply to `CREATE`, `UPDATE`, `DELETE` operations on groups starting with `osd-`. (default: `osd-sre-`)
+* `GROUP_VALIDATION_ADMIN_GROUP` - Admin groups, which the requestor must be a member in order to have access granted. This is comma-separated. (default: `osd-sre-admins,osd-sre-cluster-admins`)
+* `DEBUG_GROUP_VALIDATION` - Debug the webhook? Set to `True` to enable, all other values (including absent) disable. (default: False)
 
 ### Subscription Validation
 

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -31,6 +31,11 @@ def handle_request():
     body_dict = request.json['request']
     group_name = body_dict['object']['metadata']['name']
     userinfo = body_dict['userInfo']
+    if userinfo['username'] == "kube:admin":
+      # kubeadmin can do anything
+      if debug:
+        print("Performing action: {} in {} group for kube:admin".format(body_dict['operation'],group_name))
+      return responses.response_allow(req=body_dict)
     if group_name.startswith(group_prefix):
       if debug:
         print("Performing action: {} in {} group".format(body_dict['operation'],group_name))

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -8,7 +8,9 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("group-webhook", __name__)
 
 group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins")
+admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins")
+
+admin_groups = admin_group.split(",")
 
 @bp.route('/group-validation', methods=['POST'])
 def handle_request():
@@ -39,7 +41,7 @@ def handle_request():
     if group_name.startswith(group_prefix):
       if debug:
         print("Performing action: {} in {} group".format(body_dict['operation'],group_name))
-      if admin_group in userinfo['groups']:
+      if len(set(userinfo['groups']) & set(admin_groups)) > 0:
         response_body = responses.response_allow(req=body_dict,msg="{} group {}".format(body_dict['operation'], group_name))
       else:
         deny_msg = "User not authorized to {} group {}".format(body_dict['operation'],group_name)

--- a/templates/20-validation-webhook.deployment.yaml.tmpl
+++ b/templates/20-validation-webhook.deployment.yaml.tmpl
@@ -30,7 +30,7 @@ spec:
         - name: SUBSCRIPTION_VALIDATION_NAMESPACES
           value: "openshift-operators"
         - name: GROUP_VALIDATION_ADMIN_GROUP
-          value: "osd-sre-admins"
+          value: "osd-sre-admins,osd-sre-cluster-admins"
         - name: GROUP_VALIDATION_PREFIX
           value: "osd-sre-"
         command: 


### PR DESCRIPTION
We may need to refactor this later to encapsulate more permissions, but
for now, kube:admin functions as "`root`", and can do anything.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>