### PR TITLE
Remove obsolete single webhook reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A Flask app designed to act as a webhook admission controller for OpenShift.
 
-Presently there is a single webhook, [group-validation](#group_validation), which is provided via `/group-validation` endpoint.
-
 ## Webhooks
 
 ### Group Validation


### PR DESCRIPTION
There are now more than one webhook, and so the removed reference no longer makes sense.