### PR TITLE
Replace safelisted NS for Subscriptions with openshift-marketplace NS

### DIFF
--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -7,7 +7,7 @@ from webhook.request_helper import validate, responses
 
 bp = Blueprint("subscription-webhook", __name__)
 
-valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-operators")
+valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace")
 
 valid_source_namespaces = valid_source_namespaces.split(",")
 

--- a/templates/20-validation-webhook.deployment.yaml.tmpl
+++ b/templates/20-validation-webhook.deployment.yaml.tmpl
@@ -27,7 +27,7 @@ spec:
         imagePullPolicy: Always
         env:
         - name: SUBSCRIPTION_VALIDATION_NAMESPACES
-          value: "openshift-operators"
+          value: "openshift-marketplace"
         - name: GROUP_VALIDATION_ADMIN_GROUP
           value: "osd-sre-admins,osd-sre-cluster-admins"
         - name: GROUP_VALIDATION_PREFIX


### PR DESCRIPTION
Since all official CatalogSources/OperatorSources reside in the openshift-marketplace NS, update the safelisted NS for sourceNamespaces