### PR TITLE
Expose metrics for validation webhooks

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.1.1
 gunicorn==19.9.0
 kubernetes==10.0.1
+prometheus_client==0.7.1

--- a/src/webhook/__init__.py
+++ b/src/webhook/__init__.py
@@ -8,3 +8,6 @@ app.register_blueprint(group_validation.bp)
 
 from webhook import subscription_validation
 app.register_blueprint(subscription_validation.bp)
+
+from webhook import metrics
+app.register_blueprint(metrics.bp)

--- a/src/webhook/metrics.py
+++ b/src/webhook/metrics.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, Response
+import prometheus_client
+
+bp = Blueprint("metrics", __name__)
+
+# send metrics in text format using 0.0.4 version
+CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
+
+@bp.route('/metrics')
+def metrics():
+    return Response(prometheus_client.generate_latest(), mimetype=CONTENT_TYPE_LATEST)

--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -1,18 +1,26 @@
-from flask import request, Blueprint
+from flask import request, Blueprint, Response
 import sys, traceback
 import json
 import os
+import prometheus_client
+from prometheus_client import Counter
+from prometheus_client.core import CollectorRegistry
 
 from webhook.request_helper import validate, responses
 
 bp = Blueprint("subscription-webhook", __name__)
 
-valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace")
+# define what we track, declare Counter, how many times this route is accessed
+TOTAL_SUBSCRIPTION = Counter('webhook_subscription_validation_total', 'The total number of subscription validation requests')
+DENIED_SUBSCRIPTION = Counter('webhook_subscription_validation_denied', 'The total number of subscription validation requests denied')
 
+valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace")
 valid_source_namespaces = valid_source_namespaces.split(",")
 
 @bp.route('/subscription-validation', methods=['POST'])
 def handle_request():
+  # inc total subscription counter
+  TOTAL_SUBSCRIPTION.inc()
   debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
   debug = (debug == "True")
 
@@ -26,6 +34,8 @@ def handle_request():
     valid = False
 
   if not valid:
+    # inc denied subscription counter
+    DENIED_SUBSCRIPTION.inc()
     return responses.response_invalid()
   
   try:

--- a/templates/01-webhook.namespace.yaml.tmpl
+++ b/templates/01-webhook.namespace.yaml.tmpl
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "#NAMESPACE#"
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/templates/02-prometheus-role-binding.yaml.tmpl
+++ b/templates/02-prometheus-role-binding.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-validation-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/templates/02-prometheus_role.yaml.tmpl
+++ b/templates/02-prometheus_role.yaml.tmpl
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-validation-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/templates/05-validation-webhook.service.yaml.tmpl
+++ b/templates/05-validation-webhook.service.yaml.tmpl
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: "#CABUNDLECONFIGMAP#"
+  labels:
+    name: "#SVCNAME#"
   name: "#SVCNAME#"
   namespace: "#NAMESPACE#"
 spec:

--- a/templates/30-validation-webhook.servicemonitor.yaml.tmpl
+++ b/templates/30-validation-webhook.servicemonitor.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: "#SVCNAME#"
+  name: "#SVCNAME#"
+  namespace: "#NAMESPACE#"
+spec:
+  endpoints:
+  - port: "https"
+    scheme: "https"
+    tlsConfig: 
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: validation-webhook.openshift-validation-webhook.svc
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      name: "#SVCNAME#"


### PR DESCRIPTION
Added following metrics:

1. webhook_subscription_validation - The total number of subscription validation requests
2. webhook_denied_subscription - The total number of subscription validation requests denied
3. webhook_group_validation - The total number of group validation requests
4. webhook_denied_group - The total number of group validation requests denied