### PR TITLE
Base image off of ubi

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,18 @@
-FROM python:3.7
+FROM registry.access.redhat.com/ubi8/ubi
 
+# Install python
+RUN yum install python3 --nodocs --assumeyes
 
-ADD src /app
+# Prep working directory
+RUN mkdir -p /app
 WORKDIR /app
-RUN pip install -r /app/requirements.txt
+
+# Copy requirements file and install dependencies
+COPY src/requirements.txt ./
+RUN pip3 install -r /app/requirements.txt
+
+# Copy rest of application
+COPY src/. .
 ENV FLASK_APP=webhook
 EXPOSE 5000
 


### PR DESCRIPTION
Moving to a UBI image will ensure we have a better security footprint, as well as it will let us spin up CI on this repo (ref https://github.com/openshift/release/pull/7041).

I also switched around the order of the Dockerfile as well to improve build speed, as dependencies will be cached when doing local builds.

/cc @rogbas @csheremeta 