### PR TITLE
Reverting to old way of pushing image in the bash script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,6 @@ build-base: build/Dockerfile
 push-base: build/Dockerfile
 	$(CONTAINER_ENGINE) push $(IMG):$(IMAGETAG)
 
-.PHONY: skopeo-push
-skopeo-push:
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${IMG}:${IMAGETAG}" \
-		"docker://${IMG}:latest"
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${IMG}:${IMAGETAG}" \
-		"docker://${IMG}:${IMAGETAG}"
-
-
 # TODO: Change the render to allow for the permissions to have a list of all the webhook names
 # TODO: Pull that list of names from the yaml files?
 render: $(TEMPLATEFILES) build/Dockerfile

--- a/build/build_deploy.sh
+++ b/build/build_deploy.sh
@@ -4,6 +4,21 @@
 
 set -exv
 
-# build the image, the selectorsyncset, and push the imate
-QUAY_USER="app-sre" IMAGETAG="$IMAGETAG" make render build-sss build-base skopeo-push
+CURRENT_DIR=$(dirname "$0")
+
+BASE_IMG="managed-cluster-validating-webhooks"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+GIT_HASH=$(git rev-parse --short=7 HEAD)
+IMAGETAG="${GIT_HASH}"
+
+# build the image and the selectorsyncset
+QUAY_USER="app-sre" IMAGETAG="$IMAGETAG" make render build-sss build-base
+
+#push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${QUAY_IMAGE}:${IMAGETAG}" \
+    "docker://${QUAY_IMAGE}:latest"
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${QUAY_IMAGE}:${IMAGETAG}" \
+    "docker://${QUAY_IMAGE}:${IMAGETAG}"
 


### PR DESCRIPTION
The move to make isn't working.
Debugging requires a PR and merge, which is a pain.
This moves back to what it was doing before in the bash script.
If it doesn't work I'll have to install skopeo to reproduce locally but hoping not.