### PR TITLE
failurePolicy should be 'Ignore' or it causes cluster bring-up to fail

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -159,7 +159,7 @@ objects:
             namespace: openshift-validation-webhook
             name: validation-webhook
             path: /namespace-validation
-        failurePolicy: Fail
+        failurePolicy: Ignore
         name: namespace-validation.managed.openshift.io
         rules:
         - operations:
@@ -183,7 +183,7 @@ objects:
             namespace: openshift-validation-webhook
             name: validation-webhook
             path: /regular-user-validation
-        failurePolicy: Fail
+        failurePolicy: Ignore
         name: regular-user-validation.managed.openshift.io
         rules:
         - operations:

--- a/templates/10-namespace-validation.ValidatingWebhookConfiguration.yaml.tmpl
+++ b/templates/10-namespace-validation.ValidatingWebhookConfiguration.yaml.tmpl
@@ -14,7 +14,7 @@ webhooks:
         name: "#SVCNAME#"
         path: /namespace-validation
     failurePolicy:
-      "Fail"
+      "Ignore"
     name: namespace-validation.managed.openshift.io
     rules: 
       - operations: 

--- a/templates/10-regular-user-validation.ValidatingWebhookConfiguration.yaml.tmpl
+++ b/templates/10-regular-user-validation.ValidatingWebhookConfiguration.yaml.tmpl
@@ -14,7 +14,7 @@ webhooks:
         name: "#SVCNAME#"
         path: /regular-user-validation
     failurePolicy:
-      "Fail"
+      "Ignore"
     name: regular-user-validation.managed.openshift.io
     rules: 
       - operations:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-2828
https://bugzilla.redhat.com/show_bug.cgi?id=1803956

Webhooks for Namespaces and denying access to users must fail open, i.e. policy = "Ignore", else cluster provisioning will fail if the webhook is not already online.  This race condition is happening a lot on OCP 4.4.0 rc builds.