### PR TITLE
Un-ignore and fix remaining pep8 rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,7 @@ test-container:
 
 .PHONY: lint
 lint: test-container
-	# E111 indentation is not a multiple of four
-	# E121 continuation line under-indented for hanging indent
-	# E401 multiple imports on one line
-	# E402 module level import not at top of file
-	# E501 line too long (N > 79 characters)
-	# E722 do not use bare 'except'
-	# W293 blank line contains whitespace
-	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; flake8 --ignore E111,E121,E114,E401,E402,E501,E722,W293 src/"
+	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; flake8 src/ build/"
 
 .PHONY: test
 test: test-container

--- a/build/generate_syncset.py
+++ b/build/generate_syncset.py
@@ -1,30 +1,36 @@
 #!/usr/bin/env python
 
-import oyaml as yaml
-
 import os
-import sys
 import argparse
 import copy
 
+import oyaml as yaml
+
+
+TPL = "00-osd-managed-cluster-validating-webhooks.selectorsyncset.yaml.tmpl"
+
+
 def get_yaml_all(filename):
-    with open(filename,'r') as input_file:
+    with open(filename, 'r') as input_file:
         return list(yaml.load_all(input_file))
 
+
 def get_yaml(filename):
-    with open(filename,'r') as input_file:
+    with open(filename, 'r') as input_file:
         return yaml.safe_load(input_file)
+
 
 def get_all_yaml_files(path):
     file_paths = []
-    for r,d,f in os.walk(path):
+    for r, _, f in os.walk(path):
         for file in f:
             if file.endswith('.tmpl') or file.endswith('.yaml'):
-                file_paths.append(os.path.join(r,file))
+                file_paths.append(os.path.join(r, file))
         # break, so we don't recurse
         break
     file_paths = sorted(file_paths)
     return file_paths
+
 
 def get_all_yaml_obj(file_paths):
     yaml_objs = []
@@ -34,37 +40,43 @@ def get_all_yaml_obj(file_paths):
             yaml_objs.append(obj)
     return yaml_objs
 
+
 def process_yamls(directory):
     # Get all yaml files as array of yaml objects
     yamls = get_all_yaml_obj(get_all_yaml_files(directory))
     if len(yamls) == 0:
         return
-    
-    
 
-    
     for obj in template_data['objects']:
         obj['spec']['resources'] = []
         if obj['kind'] == 'SelectorSyncSet':
             for y in yamls:
                 obj['spec']['resources'].append(y)
-    
+
     output_data['objects'].append(obj)
-    
 
 
 if __name__ == '__main__':
-    #Argument parser
-    parser = argparse.ArgumentParser(description="selectorsyncset generation tool", usage='%(prog)s [options]')
-    parser.add_argument("--template-dir", "-t", required=True, help="Path to template directory [required]")
-    parser.add_argument("--build-dir", "-b", required=True, help="Path to folder containing yaml files [required]")
-    parser.add_argument("--destination", "-d", required=True, help="Destination for selectorsynceset file [required]")
-    parser.add_argument("--repo-name", "-r", required=True, help="Name of the repository [required]")
+    # Argument parser
+    parser = argparse.ArgumentParser(
+        description="selectorsyncset generation tool",
+        usage='%(prog)s [options]')
+    parser.add_argument(
+        "--template-dir", "-t", required=True,
+        help="Path to template directory [required]")
+    parser.add_argument(
+        "--build-dir", "-b", required=True,
+        help="Path to folder containing yaml files [required]")
+    parser.add_argument(
+        "--destination", "-d", required=True,
+        help="Destination for selectorsynceset file [required]")
+    parser.add_argument(
+        "--repo-name", "-r", required=True,
+        help="Name of the repository [required]")
     arguments = parser.parse_args()
 
     # Get the template data
-    template_data = get_yaml(os.path.join(arguments.build_dir, "00-osd-managed-cluster-validating-webhooks.selectorsyncset.yaml.tmpl"))
-    #selectorsyncset_data = get_yaml(os.path.join(arguments.template_dir, "selectorsyncset.yaml"))
+    template_data = get_yaml(os.path.join(arguments.build_dir, TPL))
 
     # The templates and script are shared across repos (copy & paste).
     # Set the REPO_NAME parameter.
@@ -75,10 +87,10 @@ if __name__ == '__main__':
     output_data = copy.deepcopy(template_data)
     output_data.pop("objects")
     output_data['objects'] = []
-    
+
     # for each subdir of yaml_directory append 'object' to template
     process_yamls(arguments.template_dir)
 
     # write template file ordering by keys
-    with open(arguments.destination,'w') as outfile:
+    with open(arguments.destination, 'w') as outfile:
         yaml.dump(output_data, outfile)

--- a/src/gunicorn.py
+++ b/src/gunicorn.py
@@ -1,6 +1,7 @@
 # gunicorn config file
 
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "pid=%(p)s"'
+access_log_format = (
+    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "pid=%(p)s"')
 raw_env = [
   'FLASK_APP=webhook'
 ]

--- a/src/init.py
+++ b/src/init.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python3
 
-# Update the ValidatingWebhookConfiguration with the contents of the Service CA.
+# Update the ValidatingWebhookConfiguration with the contents of the Service
+# CA.
 
-from kubernetes import client, config
-import os
 import argparse
-import copy
 import base64
+import copy
+import os
+
+from kubernetes import client
+from kubernetes import config
 
 parser = argparse.ArgumentParser(description="Options to Program")
-parser.add_argument('-a', default="managed.openshift.io/inject-cabundle-from", dest='annotation_name', help='What is the annotation that has a reference to a namespace/configmap for the caBundle. The cert must be stored in pem format in a key called service-ca.crt')
+parser.add_argument(
+    '-a',
+    default="managed.openshift.io/inject-cabundle-from",
+    dest='annotation_name',
+    help='What is the annotation that has a reference to a '
+         'namespace/configmap for the caBundle. The cert must be stored in '
+         'pem format in a key called service-ca.crt')
 parsed = parser.parse_args()
 
 config.load_incluster_config()
@@ -17,42 +26,55 @@ admission_client = client.AdmissionregistrationV1beta1Api()
 cm_client = client.CoreV1Api()
 
 
-def get_cert_from_configmap(client, namespace, configmap_name, key="service-ca.crt"):
-  try:
-    o = client.read_namespaced_config_map(configmap_name, namespace)
-    if key in o.data:
-      return o.data[key].rstrip()
-  except:
+def get_cert_from_configmap(client, namespace, configmap_name,
+                            key="service-ca.crt"):
+    try:
+        o = client.read_namespaced_config_map(configmap_name, namespace)
+        if key in o.data:
+            return o.data[key].rstrip()
+    except Exception:
+        return None
     return None
-  return None
 
 
 def encode_cert(cert):
-  return base64.b64encode(cert.encode("UTF-8")).decode("UTF-8")
+    return base64.b64encode(cert.encode("UTF-8")).decode("UTF-8")
 
 
-def get_validating_webhook_configuration_objects_with_annotation(client, annotation):
-  ret = []
-  for o in client.list_validating_webhook_configuration().items:
-    if o.metadata.annotations is not None and annotation in o.metadata.annotations:
-      ret.append(o)
-  return ret
+def get_validating_webhook_configuration_objects_with_annotation(client,
+                                                                 annotation):
+    ret = []
+    for o in client.list_validating_webhook_configuration().items:
+        if (o.metadata.annotations is not None and
+                annotation in o.metadata.annotations):
+            ret.append(o)
+    return ret
 
 
-for vwc in get_validating_webhook_configuration_objects_with_annotation(admission_client, parsed.annotation_name):
-  ns, cm_name = vwc.metadata.annotations[parsed.annotation_name].split('/')
-  cert = get_cert_from_configmap(cm_client, ns, cm_name)
-  if cert is None:
-    print("WARNING: Skipping validatingwebhookconfiguration/{}: Couldn't find a cert from {}/{} ConfigMap. \n".format(vwc.metadata.name, ns, cm_name))
-    continue
-  encoded_cert = encode_cert(cert)
-  new_vwc = copy.deepcopy(vwc)
-  for hook in new_vwc.webhooks:
-    if hook.client_config.service is not None and hook.client_config.ca_bundle is not encoded_cert:
-      hook.client_config.ca_bundle = encoded_cert
-      print("validatingwebhookconfiguration/{}: Injecting caBundle from {}/{}, for hook name {}, to service/{}/{}\n".format(new_vwc.metadata.name, ns, cm_name, hook.name, hook.client_config.service.namespace, hook.client_config.service.name))
-  try:
-    result = admission_client.patch_validating_webhook_configuration(name=new_vwc.metadata.name, body=new_vwc)
-  except Exception as err:
-    print("ERROR: Couldn't save validatingwebhookconfiguration/{}: {}\n", new_vwc.metadata.name, err)
-    os.exit(1)
+for vwc in get_validating_webhook_configuration_objects_with_annotation(
+        admission_client, parsed.annotation_name):
+    ns, cm_name = vwc.metadata.annotations[parsed.annotation_name].split('/')
+    cert = get_cert_from_configmap(cm_client, ns, cm_name)
+    if cert is None:
+        print("WARNING: Skipping validatingwebhookconfiguration/{}: Couldn't "
+              "find a cert from {}/{} ConfigMap. \n".format(
+                  vwc.metadata.name, ns, cm_name))
+        continue
+    encoded_cert = encode_cert(cert)
+    new_vwc = copy.deepcopy(vwc)
+    for hook in new_vwc.webhooks:
+        if (hook.client_config.service is not None and
+                hook.client_config.ca_bundle is not encoded_cert):
+            hook.client_config.ca_bundle = encoded_cert
+            print("validatingwebhookconfiguration/{}: Injecting caBundle from "
+                  "{}/{}, for hook name {}, to service/{}/{}\n".format(
+                      new_vwc.metadata.name, ns, cm_name, hook.name,
+                      hook.client_config.service.namespace,
+                      hook.client_config.service.name))
+    try:
+        result = admission_client.patch_validating_webhook_configuration(
+            name=new_vwc.metadata.name, body=new_vwc)
+    except Exception as err:
+        print("ERROR: Couldn't save validatingwebhookconfiguration/{}: "
+              "{}\n".format(new_vwc.metadata.name, err))
+        os.exit(1)

--- a/src/webhook/__init__.py
+++ b/src/webhook/__init__.py
@@ -1,18 +1,13 @@
-from flask import Flask
-
-app = Flask(__name__, instance_relative_config=True)
-
+import flask
 from webhook import group_validation
-app.register_blueprint(group_validation.bp)
-
-from webhook import subscription_validation
-app.register_blueprint(subscription_validation.bp)
-
-from webhook import namespace_validation
-app.register_blueprint(namespace_validation.bp)
-
-from webhook import regular_user_validation
-app.register_blueprint(regular_user_validation.bp)
-
 from webhook import metrics
+from webhook import namespace_validation
+from webhook import regular_user_validation
+from webhook import subscription_validation
+
+app = flask.Flask(__name__, instance_relative_config=True)
+app.register_blueprint(group_validation.bp)
+app.register_blueprint(subscription_validation.bp)
+app.register_blueprint(namespace_validation.bp)
+app.register_blueprint(regular_user_validation.bp)
 app.register_blueprint(metrics.bp)

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -1,71 +1,89 @@
-from flask import request, Blueprint
-import sys, traceback
 import os
-from prometheus_client import Counter
-from webhook.request_helper import validate, responses
+import sys
+import traceback
 
-bp = Blueprint("group-webhook", __name__)
+import flask
+import prometheus_client
+
+from webhook.request_helper import responses
+from webhook.request_helper import validate
+
+bp = flask.Blueprint("group-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_GROUP = Counter('webhook_group_validation_total', 'The total number of group validation requests')
-DENIED_GROUP = Counter('webhook_group_validation_denied', 'The total number of group validation requests denied')
+TOTAL_GROUP = prometheus_client.Counter(
+    'webhook_group_validation_total',
+    'The total number of group validation requests')
+DENIED_GROUP = prometheus_client.Counter(
+    'webhook_group_validation_denied',
+    'The total number of group validation requests denied')
 
 group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins")
+admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP",
+                        "osd-sre-admins,osd-sre-cluster-admins")
 
 admin_groups = admin_group.split(",")
 
 
 @bp.route('/group-validation', methods=['POST'])
 def handle_request():
-  # inc total group counter
-  TOTAL_GROUP.inc()
-  debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
-  debug = (debug == "True")
+    # inc total group counter
+    TOTAL_GROUP.inc()
+    debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
+    debug = (debug == "True")
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
-
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except:
-    valid = False
-
-  if not valid:
-    # inc denied group counter
-    DENIED_GROUP.inc()
-    return responses.response_invalid()
-
-  try:
-    body_dict = request.json['request']
-    # If trying to delete a group, must get group name from oldObject instead of object
-    if body_dict['object'] is None:
-      group_name = body_dict['oldObject']['metadata']['name']
-    else:
-      group_name = body_dict['object']['metadata']['name']
-    userinfo = body_dict['userInfo']
-    if userinfo['username'] in ("kube:admin", "system:admin"):
-      # kube/system admin can do anything
-      if debug:
-        print("Performing action: {} in {} group for {}".format(body_dict['operation'], group_name, userinfo['username']))
-      return responses.response_allow(req=body_dict)
-    if group_name.startswith(group_prefix):
-      if debug:
-        print("Performing action: {} in {} group".format(body_dict['operation'], group_name))
-      if len(set(userinfo['groups']) & set(admin_groups)) > 0:
-        response_body = responses.response_allow(req=body_dict, msg="{} group {}".format(body_dict['operation'], group_name))
-      else:
-        deny_msg = "User not authorized to {} group {}".format(body_dict['operation'], group_name)
-        response_body = responses.response_deny(req=body_dict, msg=deny_msg)
-    else:
-      response_body = responses.response_allow(req=body_dict)
     if debug:
-      print("Response body => {}".format(response_body))
-    return response_body
-  except Exception:
-    print("Exception when trying to access attributes. Request body: {}".format(request.json))
-    print("Backtrace:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+        print("REQUEST BODY => {}".format(flask.request.json))
+
+    valid = True
+    try:
+        valid = validate.validate_request_structure(flask.request.json)
+    except Exception:
+        valid = False
+
+    if not valid:
+        # inc denied group counter
+        DENIED_GROUP.inc()
+        return responses.response_invalid()
+
+    try:
+        body_dict = flask.request.json['request']
+        # If trying to delete a group, must get group name from oldObject
+        # instead of object
+        if body_dict['object'] is None:
+            group_name = body_dict['oldObject']['metadata']['name']
+        else:
+            group_name = body_dict['object']['metadata']['name']
+        userinfo = body_dict['userInfo']
+        if userinfo['username'] in ("kube:admin", "system:admin"):
+            # kube/system admin can do anything
+            if debug:
+                print("Performing action: {} in {} group for {}".format(
+                    body_dict['operation'], group_name, userinfo['username']))
+            return responses.response_allow(req=body_dict)
+        if group_name.startswith(group_prefix):
+            if debug:
+                print("Performing action: {} in {} group".format(
+                    body_dict['operation'], group_name))
+            if len(set(userinfo['groups']) & set(admin_groups)) > 0:
+                response_body = responses.response_allow(
+                    req=body_dict,
+                    msg="{} group {}".format(
+                        body_dict['operation'], group_name))
+            else:
+                deny_msg = "User not authorized to {} group {}".format(
+                    body_dict['operation'], group_name)
+                response_body = responses.response_deny(
+                    req=body_dict, msg=deny_msg)
+        else:
+            response_body = responses.response_allow(req=body_dict)
+        if debug:
+            print("Response body => {}".format(response_body))
+        return response_body
+    except Exception:
+        print("Exception when trying to access attributes. Request body: "
+              "{}".format(flask.request.json))
+        print("Backtrace:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()

--- a/src/webhook/metrics.py
+++ b/src/webhook/metrics.py
@@ -1,7 +1,7 @@
-from flask import Blueprint, Response
+import flask
 import prometheus_client
 
-bp = Blueprint("metrics", __name__)
+bp = flask.Blueprint("metrics", __name__)
 
 # send metrics in text format using 0.0.4 version
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
@@ -9,4 +9,5 @@ CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 
 @bp.route('/metrics')
 def metrics():
-    return Response(prometheus_client.generate_latest(), mimetype=CONTENT_TYPE_LATEST)
+    return flask.Response(prometheus_client.generate_latest(),
+                          mimetype=CONTENT_TYPE_LATEST)

--- a/src/webhook/namespace_validation.py
+++ b/src/webhook/namespace_validation.py
@@ -1,54 +1,78 @@
-from flask import request, Blueprint
-import sys, traceback
+import sys
+import traceback
 import os
 import re
-from prometheus_client import Counter
 
-from webhook.request_helper import validate, responses
+import flask
+import prometheus_client
 
-bp = Blueprint("namespace-webhook", __name__)
+from webhook.request_helper import responses
+from webhook.request_helper import validate
+
+bp = flask.Blueprint("namespace-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_NAMESPACE = Counter('webhook_namespace_validation_total', 'The total number of namespace validation requests')
-DENIED_NAMESPACE = Counter('webhook_namespace_validation_denied', 'The total number of namespace validation requests denied')
+TOTAL_NAMESPACE = prometheus_client.Counter(
+    'webhook_namespace_validation_total',
+    'The total number of namespace validation requests')
+DENIED_NAMESPACE = prometheus_client.Counter(
+    'webhook_namespace_validation_denied',
+    'The total number of namespace validation requests denied')
+
+# Use this with .match, which has an implicit start anchor (^)
+PRIV_NS_RE = re.compile('|'.join(
+    [
+        'kube-.*',
+        'openshift.*',
+        'ops-health-monitoring$',
+        'management-infra$',
+        'default$',
+        'logging$',
+        'sre-app-check$',
+        'redhat-.*',
+    ]
+))
 
 
 @bp.route('/namespace-validation', methods=['POST'])
 def handle_request():
-  # inc total namespace counter
-  TOTAL_NAMESPACE.inc()
-  debug = os.getenv("DEBUG_NAMESPACE_VALIDATION", "False")
-  debug = (debug == "True")
+    # inc total namespace counter
+    TOTAL_NAMESPACE.inc()
+    debug = os.getenv("DEBUG_NAMESPACE_VALIDATION", "False")
+    debug = (debug == "True")
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+    if debug:
+        print("REQUEST BODY => {}".format(flask.request.json))
 
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except Exception:
-    valid = False
+    valid = True
+    try:
+        valid = validate.validate_request_structure(flask.request.json)
+    except Exception:
+        valid = False
 
-  if not valid:
-    # inc denied namespace counter
-    DENIED_NAMESPACE.inc()
-    return responses.response_invalid()
-  
-  try:
-    body_dict = request.json['request']
-    requester_group_memberships = body_dict['userInfo']['groups']
-    if "dedicated-admins" in requester_group_memberships:
-      requested_ns = body_dict['namespace']
-      privileged_namespace_re = '(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$|^redhat-.*)'
-      # match will return a match object if the namespace matches the regex, or None if the namespace doesn't match the regex
-      if re.match(privileged_namespace_re, requested_ns) is not None:
-        return responses.response_deny(req=body_dict, msg="You cannot update the privileged namespace {}.".format(requested_ns))
-      else:
-        return responses.response_allow(req=body_dict)
-    else:
-      return responses.response_allow(req=body_dict)
-  except Exception:
-    print("Exception:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+    if not valid:
+        # inc denied namespace counter
+        DENIED_NAMESPACE.inc()
+        return responses.response_invalid()
+
+    try:
+        body_dict = flask.request.json['request']
+        requester_group_memberships = body_dict['userInfo']['groups']
+        if "dedicated-admins" in requester_group_memberships:
+            requested_ns = body_dict['namespace']
+            # match will return a match object if the namespace matches the
+            # regex, or None if the namespace doesn't match the regex.
+            if PRIV_NS_RE.match(requested_ns) is not None:
+                return responses.response_deny(
+                    req=body_dict,
+                    msg="You cannot update the privileged namespace "
+                        "{}.".format(requested_ns))
+            else:
+                return responses.response_allow(req=body_dict)
+        else:
+            return responses.response_allow(req=body_dict)
+    except Exception:
+        print("Exception:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()

--- a/src/webhook/regular_user_validation.py
+++ b/src/webhook/regular_user_validation.py
@@ -1,76 +1,84 @@
-from flask import request, Blueprint
-import sys, traceback
+import sys
+import traceback
 import os
 
-from webhook.request_helper import validate, responses
+import flask
 
-bp = Blueprint("regular-user-webhook", __name__)
+from webhook.request_helper import responses
+from webhook.request_helper import validate
 
-# the groups allowed to administer resources in cluster (i.e. exempt from this webhook)
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins")
+bp = flask.Blueprint("regular-user-webhook", __name__)
+
+# the groups allowed to administer resources in cluster (i.e. exempt from this
+# webhook)
+admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP",
+                        "osd-sre-admins,osd-sre-cluster-admins")
 
 admin_groups = admin_group.split(",")
 
 
 @bp.route('/regular-user-validation', methods=['POST'])
 def handle_request():
-  debug = os.getenv("DEBUG_REGULAR_USER_DENIER", "False")
-  debug = (debug == "True")
+    debug = os.getenv("DEBUG_REGULAR_USER_DENIER", "False")
+    debug = (debug == "True")
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+    if debug:
+        print("REQUEST BODY => {}".format(flask.request.json))
 
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except Exception:
-    valid = False
+    valid = True
+    try:
+        valid = validate.validate_request_structure(flask.request.json)
+    except Exception:
+        valid = False
 
-  if not valid:
-    return responses.response_invalid()
-  
-  return get_response(request, debug)
+    if not valid:
+        return responses.response_invalid()
+
+    return get_response(flask.request, debug)
 
 
 def get_response(req, debug=False):
-  if debug:
-    print("REQUEST BODY => {}".format(req.json))
+    if debug:
+        print("REQUEST BODY => {}".format(req.json))
 
-  try:
-    body_dict = req.json['request']
-    username = body_dict['userInfo']['username']
-    groups = body_dict['userInfo']['groups']
+    try:
+        body_dict = req.json['request']
+        username = body_dict['userInfo']['username']
+        groups = body_dict['userInfo']['groups']
 
-    if is_request_allowed(username, groups, admin_groups):
-      return responses.response_allow(req=body_dict)
-    else:
-      if body_dict['object'] is None:
-        kind = body_dict['oldObject']['kind']
-      else:
-        kind = body_dict['object']['kind']
-      operation = body_dict['operation']
-      return responses.response_deny(req=body_dict, msg="Regular user '{}' cannot {} kind '{}'.".format(username, operation, kind))
-  except Exception:
-    print("Exception:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+        if is_request_allowed(username, groups, admin_groups):
+            return responses.response_allow(req=body_dict)
+        else:
+            if body_dict['object'] is None:
+                kind = body_dict['oldObject']['kind']
+            else:
+                kind = body_dict['object']['kind']
+            operation = body_dict['operation']
+            return responses.response_deny(
+                req=body_dict,
+                msg="Regular user '{}' cannot {} kind '{}'."
+                    .format(username, operation, kind))
+    except Exception:
+        print("Exception:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()
 
 
 def is_request_allowed(username, groups, admin_groupnames=()):
-  """Decide if it's a special user (SA, kube:admin, etc) or not.
+    """Decide if it's a special user (SA, kube:admin, etc) or not.
 
-  reference: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request
-  """
-  # unauthenticated is DENY
-  if username == "system:unauthenticated":
+    reference: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request  # noqa
+    """
+    # unauthenticated is DENY
+    if username == "system:unauthenticated":
+        return False
+    # system users is ALLOW
+    if username.startswith("kube:") or username.startswith("system:"):
+        return True
+    # SRE groups are ALLOW
+    for group in groups:
+        if group in admin_groupnames:
+            return True
+    # else DENY
     return False
-  # system users is ALLOW
-  if username.startswith("kube:") or username.startswith("system:"):
-    return True
-  # SRE groups are ALLOW
-  for group in groups:
-    if group in admin_groupnames:
-      return True
-  # else DENY
-  return False

--- a/src/webhook/request_helper/responses.py
+++ b/src/webhook/request_helper/responses.py
@@ -18,12 +18,14 @@ def response_base(req, allowed, msg=''):
 
 
 def response_allow(req, msg="Allowed resource for this cluster"):
-    print("[pid={}] Allowing admission {}: {}".format(os.getpid(), req['userInfo']['username'], msg))
+    print("[pid={}] Allowing admission {}: {}".format(
+        os.getpid(), req['userInfo']['username'], msg))
     return response_base(req=req, allowed=True, msg="Access granted")
 
 
 def response_deny(req, msg="Prohibited resource for this cluster"):
-    print("[pid={}] Denying admission {}: {}".format(os.getpid(), req['userInfo']['username'], msg))
+    print("[pid={}] Denying admission {}: {}".format(
+        os.getpid(), req['userInfo']['username'], msg))
     return response_base(req=req, allowed=False, msg=msg)
 
 

--- a/src/webhook/request_helper/validate.py
+++ b/src/webhook/request_helper/validate.py
@@ -1,11 +1,10 @@
 def validate_request_structure(request_json):
-  """Validate the request structure.
-  """
+    """Validate the request structure."""
 
-  doc_keys = request_json.keys()
+    doc_keys = request_json.keys()
 
-  if 'kind' not in doc_keys:
+    if 'kind' not in doc_keys:
+        return False
+    if request_json['kind'] == "AdmissionReview":
+        return True
     return False
-  if request_json['kind'] == "AdmissionReview":
-    return True
-  return False

--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -1,52 +1,65 @@
-from flask import request, Blueprint
-import sys, traceback
+import sys
+import traceback
 import os
-from prometheus_client import Counter
-from webhook.request_helper import validate, responses
 
-bp = Blueprint("subscription-webhook", __name__)
+import flask
+import prometheus_client
+
+from webhook.request_helper import responses
+from webhook.request_helper import validate
+
+bp = flask.Blueprint("subscription-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_SUBSCRIPTION = Counter('webhook_subscription_validation_total', 'The total number of subscription validation requests')
-DENIED_SUBSCRIPTION = Counter('webhook_subscription_validation_denied', 'The total number of subscription validation requests denied')
+TOTAL_SUBSCRIPTION = prometheus_client.Counter(
+    'webhook_subscription_validation_total',
+    'The total number of subscription validation requests')
+DENIED_SUBSCRIPTION = prometheus_client.Counter(
+    'webhook_subscription_validation_denied',
+    'The total number of subscription validation requests denied')
 
-valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace")
+valid_source_namespaces = os.getenv(
+    "SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace")
 valid_source_namespaces = valid_source_namespaces.split(",")
 
 
 @bp.route('/subscription-validation', methods=['POST'])
 def handle_request():
-  # inc total subscription counter
-  TOTAL_SUBSCRIPTION.inc()
-  debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
-  debug = (debug == "True")
+    # inc total subscription counter
+    TOTAL_SUBSCRIPTION.inc()
+    debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
+    debug = (debug == "True")
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+    if debug:
+        print("REQUEST BODY => {}".format(flask.request.json))
 
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except Exception:
-    valid = False
+    valid = True
+    try:
+        valid = validate.validate_request_structure(flask.request.json)
+    except Exception:
+        valid = False
 
-  if not valid:
-    # inc denied subscription counter
-    DENIED_SUBSCRIPTION.inc()
-    return responses.response_invalid()
-  
-  try:
-    body_dict = request.json['request']
-    requester_group_memberships = body_dict['userInfo']['groups']
-    if "dedicated-admins" in requester_group_memberships:
-      if body_dict['object']['spec']['sourceNamespace'] not in valid_source_namespaces:
-        return responses.response_deny(req=body_dict, msg="You cannot manage Subscriptions that target {}.".format(body_dict['object']['spec']['sourceNamespace']))
-      else:
-        return responses.response_allow(req=body_dict)
-    else:
-      return responses.response_allow(req=body_dict)
-  except Exception:
-    print("Exception:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+    if not valid:
+        # inc denied subscription counter
+        DENIED_SUBSCRIPTION.inc()
+        return responses.response_invalid()
+
+    try:
+        body_dict = flask.request.json['request']
+        requester_group_memberships = body_dict['userInfo']['groups']
+        source_namespace = body_dict['object']['spec']['sourceNamespace']
+        if "dedicated-admins" in requester_group_memberships:
+            if source_namespace not in valid_source_namespaces:
+                return responses.response_deny(
+                    req=body_dict,
+                    msg="You cannot manage Subscriptions that target "
+                        "{}.".format(source_namespace))
+            else:
+                return responses.response_allow(req=body_dict)
+        else:
+            return responses.response_allow(req=body_dict)
+    except Exception:
+        print("Exception:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()

--- a/src/webhook/test_regular_user_validation.py
+++ b/src/webhook/test_regular_user_validation.py
@@ -36,10 +36,11 @@ class TestRegularUserValidation_Unauthenticated(unittest.TestCase):
     username = "system:unauthenticated"
 
     def runtests(self, testGroups):
-        self.assertFalse(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
+        self.assertFalse(
+            is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
-        
+
         response = json.loads(get_response(request, debug=False))
         self.assertFalse(response['response']['allowed'])
 
@@ -63,10 +64,11 @@ class TestRegularUserValidation_kubeadmin(unittest.TestCase):
     username = "kube:admin"
 
     def runtests(self, testGroups):
-        self.assertTrue(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
+        self.assertTrue(
+            is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
-        
+
         response = json.loads(get_response(request, debug=False))
         self.assertTrue(response['response']['allowed'])
 
@@ -90,10 +92,11 @@ class TestRegularUserValidation_systemadmin(unittest.TestCase):
     username = "system:admin"
 
     def runtests(self, testGroups):
-        self.assertTrue(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
+        self.assertTrue(
+            is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
-        
+
         response = json.loads(get_response(request, debug=False))
         self.assertTrue(response['response']['allowed'])
 
@@ -120,7 +123,8 @@ class TestRegularUserValidation_sreUser(unittest.TestCase):
     def runtests(self, testGroups):
         # for these tests, add the SRE group to every request
         testGroups.append(self.sreGroup)
-        self.assertTrue(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
+        self.assertTrue(
+            is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
         response = json.loads(get_response(request, debug=False))
@@ -146,7 +150,8 @@ class TestRegularUserValidation_nonSreGroup(unittest.TestCase):
     username = "someOtherUser"
 
     def runtests(self, testGroups):
-        self.assertFalse(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
+        self.assertFalse(
+            is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
         response = json.loads(get_response(request, debug=False))


### PR DESCRIPTION
Commit 72ef319 via PR #41 added a flake8 check for python files in this
repo, but ignored several of the rules for the sake of expediency. This
commit pays down that technical debt by removing the ignores and fixing
those remaining violations.

There is no functional change. All the python file deltas are pure
formatting *except*:
- The privileged_namespace_re in src/webhook/namespace_validation.py is
extracted, simplified, and pre-compiled.
- Imports are tweaked to comply with best practices (import only
modules; sort imports alphabetically; group by system, 3rd party,
local).
- A couple of variables are extracted for readability and efficiency.