### PR TITLE
Split out test-requirements (and put flake8 there)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /deploy
 __pycache__
+/requirements.txt
+/test-requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ render: $(TEMPLATEFILES) build/Dockerfile
 		$$f > deploy/$$(basename $$f .tmpl) ;\
 	done
 
+# TODO: This is going to pin versions based on whatever system the
+#  target happens to be run on, which is not ideal. Should consider
+#  using the generated file as a starting point but curating real
+#  version requirements manually.
 .PHONY: requirements
 requirements:
 	if [ "$(pip list | grep pipreqs | wc -l)" != "0" ]; then \

--- a/build/Dockerfile.test
+++ b/build/Dockerfile.test
@@ -2,6 +2,6 @@ FROM python:3
 
 # Install modules
 COPY src/requirements.txt ./
+COPY src/test-requirements.txt ./
 ENV PYTHONDONTWRITEBYTECODE="true"
-RUN pip install -r requirements.txt --no-cache-dir
-RUN python3 -m pip install flake8 --no-cache-dir
+RUN pip install -r requirements.txt -r test-requirements.txt --no-cache-dir

--- a/src/test-requirements.txt
+++ b/src/test-requirements.txt
@@ -1,0 +1,2 @@
+# Use this file for packages needed *only* by test targets.
+flake8>=2.5.5


### PR DESCRIPTION
Following on from [1], this commit reduces the test container to a
single `pip install` command by introducing a separate
test-requirements.txt file containing flake8.

[1] https://github.com/openshift/managed-cluster-validating-webhooks/pull/41/commits/72ef3198e55392c85702bc0bfc35cdf19a0ea607#r404370367