### PR TITLE
Fix bug for regular user validation

### DIFF
--- a/src/webhook/regular_user_validation.py
+++ b/src/webhook/regular_user_validation.py
@@ -44,7 +44,10 @@ def get_response(req, debug=False):
     if is_request_allowed(username, groups, admin_groups):
       return responses.response_allow(req=body_dict)
     else:
-      kind = body_dict['object']['kind']
+      if body_dict['object'] is None:
+        kind = body_dict['oldObject']['kind']
+      else:
+        kind = body_dict['object']['kind']
       operation = body_dict['operation']
       return responses.response_deny(req=body_dict, msg="Regular user '{}' cannot {} kind '{}'.".format(username, operation, kind))
   except Exception:


### PR DESCRIPTION
"DELETE" action always failed with errors:
```
Exception:
------------------------------------------------------------
Traceback (most recent call last):
  File "/app/webhook/regular_user_validation.py", line 34, in handle_request
    kind = body_dict['object']['kind']
TypeError: 'NoneType' object is not subscriptable
10.129.0.1 - - [15/Apr/2020:08:48:53 +0000] "POST /regular-user-validation?timeout=30s HTTP/1.1" 200 154 "-" "kube-apiserver-admission" "pid=<14>"
```