### PR TITLE
Update pr check to verify build-sss target is a noop

### DIFF
--- a/build/pr_check.sh
+++ b/build/pr_check.sh
@@ -4,4 +4,16 @@ set -e
 
 CURRENT_DIR=$(dirname "$0")
 
-BUILD_CMD="build-base" make lint test build-base
+BUILD_CMD="build-base" make lint test build-sss build-base
+
+# make sure nothing changed (i.e. SSS templates being invalid)
+git diff --exit-code
+MAKE_RC=$?
+
+if [ "$MAKE_RC" != "0" ];
+then
+    echo "FAILURE: unexpected changes after building.  Check that:"
+    echo " - files in templates/ dir end in '.tmpl'"
+    echo " - you have run make build-sss and committed the changes"
+    exit $MAKE_RC
+fi


### PR DESCRIPTION
Will catch if `build-sss` make target will change the generated selectorsyncset yaml.  If so, something is wrong.