### PR TITLE
Lint with black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,11 @@ test-container:
 
 .PHONY: lint
 lint: test-container
-	# E111 indentation is not a multiple of four
-	# E121 continuation line under-indented for hanging indent
-	# E401 multiple imports on one line
-	# E402 module level import not at top of file
-	# E501 line too long (N > 79 characters)
-	# E722 do not use bare 'except'
-	# W293 blank line contains whitespace
-	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; flake8 --ignore E111,E121,E114,E401,E402,E501,E722,W293 src/"
+	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; find src -name '*.py' | xargs black --check"
+
+.PHONY: black
+black:
+	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; find src -name '*.py' | xargs black"
 
 .PHONY: test
 test: test-container

--- a/src/gunicorn.py
+++ b/src/gunicorn.py
@@ -1,9 +1,9 @@
 # gunicorn config file
 
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "pid=%(p)s"'
-raw_env = [
-  'FLASK_APP=webhook'
-]
+access_log_format = (
+    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "pid=%(p)s"'
+)
+raw_env = ["FLASK_APP=webhook"]
 bind = "0.0.0.0:5000"
 workers = 5
 accesslog = "-"

--- a/src/init.py
+++ b/src/init.py
@@ -9,7 +9,12 @@ import copy
 import base64
 
 parser = argparse.ArgumentParser(description="Options to Program")
-parser.add_argument('-a', default="managed.openshift.io/inject-cabundle-from", dest='annotation_name', help='What is the annotation that has a reference to a namespace/configmap for the caBundle. The cert must be stored in pem format in a key called service-ca.crt')
+parser.add_argument(
+    "-a",
+    default="managed.openshift.io/inject-cabundle-from",
+    dest="annotation_name",
+    help="What is the annotation that has a reference to a namespace/configmap for the caBundle. The cert must be stored in pem format in a key called service-ca.crt",
+)
 parsed = parser.parse_args()
 
 config.load_incluster_config()
@@ -18,41 +23,65 @@ cm_client = client.CoreV1Api()
 
 
 def get_cert_from_configmap(client, namespace, configmap_name, key="service-ca.crt"):
-  try:
-    o = client.read_namespaced_config_map(configmap_name, namespace)
-    if key in o.data:
-      return o.data[key].rstrip()
-  except:
+    try:
+        o = client.read_namespaced_config_map(configmap_name, namespace)
+        if key in o.data:
+            return o.data[key].rstrip()
+    except:
+        return None
     return None
-  return None
 
 
 def encode_cert(cert):
-  return base64.b64encode(cert.encode("UTF-8")).decode("UTF-8")
+    return base64.b64encode(cert.encode("UTF-8")).decode("UTF-8")
 
 
 def get_validating_webhook_configuration_objects_with_annotation(client, annotation):
-  ret = []
-  for o in client.list_validating_webhook_configuration().items:
-    if o.metadata.annotations is not None and annotation in o.metadata.annotations:
-      ret.append(o)
-  return ret
+    ret = []
+    for o in client.list_validating_webhook_configuration().items:
+        if o.metadata.annotations is not None and annotation in o.metadata.annotations:
+            ret.append(o)
+    return ret
 
 
-for vwc in get_validating_webhook_configuration_objects_with_annotation(admission_client, parsed.annotation_name):
-  ns, cm_name = vwc.metadata.annotations[parsed.annotation_name].split('/')
-  cert = get_cert_from_configmap(cm_client, ns, cm_name)
-  if cert is None:
-    print("WARNING: Skipping validatingwebhookconfiguration/{}: Couldn't find a cert from {}/{} ConfigMap. \n".format(vwc.metadata.name, ns, cm_name))
-    continue
-  encoded_cert = encode_cert(cert)
-  new_vwc = copy.deepcopy(vwc)
-  for hook in new_vwc.webhooks:
-    if hook.client_config.service is not None and hook.client_config.ca_bundle is not encoded_cert:
-      hook.client_config.ca_bundle = encoded_cert
-      print("validatingwebhookconfiguration/{}: Injecting caBundle from {}/{}, for hook name {}, to service/{}/{}\n".format(new_vwc.metadata.name, ns, cm_name, hook.name, hook.client_config.service.namespace, hook.client_config.service.name))
-  try:
-    result = admission_client.patch_validating_webhook_configuration(name=new_vwc.metadata.name, body=new_vwc)
-  except Exception as err:
-    print("ERROR: Couldn't save validatingwebhookconfiguration/{}: {}\n", new_vwc.metadata.name, err)
-    os.exit(1)
+for vwc in get_validating_webhook_configuration_objects_with_annotation(
+    admission_client, parsed.annotation_name
+):
+    ns, cm_name = vwc.metadata.annotations[parsed.annotation_name].split("/")
+    cert = get_cert_from_configmap(cm_client, ns, cm_name)
+    if cert is None:
+        print(
+            "WARNING: Skipping validatingwebhookconfiguration/{}: Couldn't find a cert from {}/{} ConfigMap. \n".format(
+                vwc.metadata.name, ns, cm_name
+            )
+        )
+        continue
+    encoded_cert = encode_cert(cert)
+    new_vwc = copy.deepcopy(vwc)
+    for hook in new_vwc.webhooks:
+        if (
+            hook.client_config.service is not None
+            and hook.client_config.ca_bundle is not encoded_cert
+        ):
+            hook.client_config.ca_bundle = encoded_cert
+            print(
+                "validatingwebhookconfiguration/{}: Injecting caBundle from {}/{}, for hook name {}, to service/{}/{}\n".format(
+                    new_vwc.metadata.name,
+                    ns,
+                    cm_name,
+                    hook.name,
+                    hook.client_config.service.namespace,
+                    hook.client_config.service.name,
+                )
+            )
+    try:
+        result = admission_client.patch_validating_webhook_configuration(
+            name=new_vwc.metadata.name, body=new_vwc
+        )
+    except Exception as err:
+        print(
+            "ERROR: Couldn't save validatingwebhookconfiguration/{}: {}\n",
+            new_vwc.metadata.name,
+            err,
+        )
+        os.exit(1)

--- a/src/test-requirements.txt
+++ b/src/test-requirements.txt
@@ -1,3 +1,3 @@
 coverage==5.1
 oyaml==0.9
-flake8==3.7.9
+black==19.10b0

--- a/src/webhook/__init__.py
+++ b/src/webhook/__init__.py
@@ -3,22 +3,29 @@ from flask import Flask
 app = Flask(__name__, instance_relative_config=True)
 
 from webhook import group_validation
+
 app.register_blueprint(group_validation.bp)
 
 from webhook import subscription_validation
+
 app.register_blueprint(subscription_validation.bp)
 
 from webhook import namespace_validation
+
 app.register_blueprint(namespace_validation.bp)
 
 from webhook import regular_user_validation
+
 app.register_blueprint(regular_user_validation.bp)
 
 from webhook import metrics
+
 app.register_blueprint(metrics.bp)
 
 from webhook import user_validation
+
 app.register_blueprint(user_validation.bp)
 
 from webhook import identity_validation
+
 app.register_blueprint(identity_validation.bp)

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -7,65 +7,89 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("group-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_GROUP = Counter('webhook_group_validation_total', 'The total number of group validation requests')
-DENIED_GROUP = Counter('webhook_group_validation_denied', 'The total number of group validation requests denied')
+TOTAL_GROUP = Counter(
+    "webhook_group_validation_total", "The total number of group validation requests"
+)
+DENIED_GROUP = Counter(
+    "webhook_group_validation_denied",
+    "The total number of group validation requests denied",
+)
 
 group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins")
+admin_group = os.getenv(
+    "GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins"
+)
 
 admin_groups = admin_group.split(",")
 
 
-@bp.route('/group-validation', methods=['POST'])
+@bp.route("/group-validation", methods=["POST"])
 def handle_request():
-  # inc total group counter
-  TOTAL_GROUP.inc()
-  debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
-  debug = (debug == "True")
+    # inc total group counter
+    TOTAL_GROUP.inc()
+    debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
+    debug = debug == "True"
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
-
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except:
-    valid = False
-
-  if not valid:
-    # inc denied group counter
-    DENIED_GROUP.inc()
-    return responses.response_invalid()
-
-  try:
-    body_dict = request.json['request']
-    # If trying to delete a group, must get group name from oldObject instead of object
-    if body_dict['object'] is None:
-      group_name = body_dict['oldObject']['metadata']['name']
-    else:
-      group_name = body_dict['object']['metadata']['name']
-    userinfo = body_dict['userInfo']
-    if userinfo['username'] in ("kube:admin", "system:admin"):
-      # kube/system admin can do anything
-      if debug:
-        print("Performing action: {} in {} group for {}".format(body_dict['operation'], group_name, userinfo['username']))
-      return responses.response_allow(req=body_dict)
-    if group_name.startswith(group_prefix):
-      if debug:
-        print("Performing action: {} in {} group".format(body_dict['operation'], group_name))
-      if len(set(userinfo['groups']) & set(admin_groups)) > 0:
-        response_body = responses.response_allow(req=body_dict, msg="{} group {}".format(body_dict['operation'], group_name))
-      else:
-        deny_msg = "User not authorized to {} group {}".format(body_dict['operation'], group_name)
-        response_body = responses.response_deny(req=body_dict, msg=deny_msg)
-    else:
-      response_body = responses.response_allow(req=body_dict)
     if debug:
-      print("Response body => {}".format(response_body))
-    return response_body
-  except Exception:
-    print("Exception when trying to access attributes. Request body: {}".format(request.json))
-    print("Backtrace:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+        print("REQUEST BODY => {}".format(request.json))
+
+    valid = True
+    try:
+        valid = validate.validate_request_structure(request.json)
+    except:
+        valid = False
+
+    if not valid:
+        # inc denied group counter
+        DENIED_GROUP.inc()
+        return responses.response_invalid()
+
+    try:
+        body_dict = request.json["request"]
+        # If trying to delete a group, must get group name from oldObject instead of object
+        if body_dict["object"] is None:
+            group_name = body_dict["oldObject"]["metadata"]["name"]
+        else:
+            group_name = body_dict["object"]["metadata"]["name"]
+        userinfo = body_dict["userInfo"]
+        if userinfo["username"] in ("kube:admin", "system:admin"):
+            # kube/system admin can do anything
+            if debug:
+                print(
+                    "Performing action: {} in {} group for {}".format(
+                        body_dict["operation"], group_name, userinfo["username"]
+                    )
+                )
+            return responses.response_allow(req=body_dict)
+        if group_name.startswith(group_prefix):
+            if debug:
+                print(
+                    "Performing action: {} in {} group".format(
+                        body_dict["operation"], group_name
+                    )
+                )
+            if len(set(userinfo["groups"]) & set(admin_groups)) > 0:
+                response_body = responses.response_allow(
+                    req=body_dict,
+                    msg="{} group {}".format(body_dict["operation"], group_name),
+                )
+            else:
+                deny_msg = "User not authorized to {} group {}".format(
+                    body_dict["operation"], group_name
+                )
+                response_body = responses.response_deny(req=body_dict, msg=deny_msg)
+        else:
+            response_body = responses.response_allow(req=body_dict)
+        if debug:
+            print("Response body => {}".format(response_body))
+        return response_body
+    except Exception:
+        print(
+            "Exception when trying to access attributes. Request body: {}".format(
+                request.json
+            )
+        )
+        print("Backtrace:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()

--- a/src/webhook/identity_validation.py
+++ b/src/webhook/identity_validation.py
@@ -8,24 +8,29 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("identity-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_IDENTITY = Counter('webhook_identity_validation_total',
-                         'The total number of identity validation requests')
-DENIED_IDENTITY = Counter('webhook_identity_validation_denied',
-                          'The total number of identity validation requests denied')
+TOTAL_IDENTITY = Counter(
+    "webhook_identity_validation_total",
+    "The total number of identity validation requests",
+)
+DENIED_IDENTITY = Counter(
+    "webhook_identity_validation_denied",
+    "The total number of identity validation requests denied",
+)
 
 identity_provider = os.getenv("IDENTITY_PROVIDER", "OpenShift_SRE")
 
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP",
-                        "osd-sre-admins,osd-sre-cluster-admins")
+admin_group = os.getenv(
+    "GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins"
+)
 admin_groups = admin_group.split(",")
 
 
-@bp.route('/identity-validation', methods=['POST'])
+@bp.route("/identity-validation", methods=["POST"])
 def handle_request():
     # inc total identity counter
     TOTAL_IDENTITY.inc()
     debug = os.getenv("DEBUG_IDENTITY_VALIDATION", "False")
-    debug = (debug == "True")
+    debug = debug == "True"
 
     if debug:
         print("REQUEST BODY => {}".format(request.json))
@@ -45,34 +50,46 @@ def handle_request():
 
 def get_response(request, debug=False):
     try:
-        body_dict = request.json['request']
+        body_dict = request.json["request"]
         # If trying to delete a user, must get user name from oldObject instead of object
-        if body_dict['object'] is None:
-            identity_name = body_dict['oldObject']['metadata']['name']
-            provider_name = body_dict['oldObject']['providerName']
+        if body_dict["object"] is None:
+            identity_name = body_dict["oldObject"]["metadata"]["name"]
+            provider_name = body_dict["oldObject"]["providerName"]
         else:
-            identity_name = body_dict['object']['metadata']['name']
-            provider_name = body_dict['object']['providerName']
-        userinfo = body_dict['userInfo']
-        if userinfo['username'] in ("kube:admin", "system:admin", "system:serviceaccount:openshift-authentication:oauth-openshift"):
+            identity_name = body_dict["object"]["metadata"]["name"]
+            provider_name = body_dict["object"]["providerName"]
+        userinfo = body_dict["userInfo"]
+        if userinfo["username"] in (
+            "kube:admin",
+            "system:admin",
+            "system:serviceaccount:openshift-authentication:oauth-openshift",
+        ):
             # kube/system admin can do anything
             if debug:
-                print("Performing action: {} on identity {} by {}".format(
-                    body_dict['operation'], identity_name, userinfo['username']))
+                print(
+                    "Performing action: {} on identity {} by {}".format(
+                        body_dict["operation"], identity_name, userinfo["username"]
+                    )
+                )
             return responses.response_allow(req=body_dict)
 
         if provider_name == identity_provider:
             if debug:
-                print("Performing action: {} on {} identity".format(
-                    body_dict['operation'], identity_name))
-            if len(set(userinfo['groups']) & set(admin_groups)) > 0:
+                print(
+                    "Performing action: {} on {} identity".format(
+                        body_dict["operation"], identity_name
+                    )
+                )
+            if len(set(userinfo["groups"]) & set(admin_groups)) > 0:
                 response_body = responses.response_allow(
-                    req=body_dict, msg="{} identity {}".format(body_dict['operation'], identity_name))
+                    req=body_dict,
+                    msg="{} identity {}".format(body_dict["operation"], identity_name),
+                )
             else:
                 deny_msg = "User not authorized to {} identity {}".format(
-                    body_dict['operation'], identity_name)
-                response_body = responses.response_deny(
-                    req=body_dict, msg=deny_msg)
+                    body_dict["operation"], identity_name
+                )
+                response_body = responses.response_deny(req=body_dict, msg=deny_msg)
                 DENIED_IDENTITY.inc()
         else:
             response_body = responses.response_allow(req=body_dict)
@@ -80,8 +97,11 @@ def get_response(request, debug=False):
             print("Response body => {}".format(response_body))
         return response_body
     except Exception:
-        print("Exception when trying to access attributes. Request body: {}".format(
-            request.json))
+        print(
+            "Exception when trying to access attributes. Request body: {}".format(
+                request.json
+            )
+        )
         print("Backtrace:")
         print("-" * 60)
         traceback.print_exc(file=sys.stdout)

--- a/src/webhook/metrics.py
+++ b/src/webhook/metrics.py
@@ -4,9 +4,9 @@ import prometheus_client
 bp = Blueprint("metrics", __name__)
 
 # send metrics in text format using 0.0.4 version
-CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
+CONTENT_TYPE_LATEST = str("text/plain; version=0.0.4; charset=utf-8")
 
 
-@bp.route('/metrics')
+@bp.route("/metrics")
 def metrics():
     return Response(prometheus_client.generate_latest(), mimetype=CONTENT_TYPE_LATEST)

--- a/src/webhook/namespace_validation.py
+++ b/src/webhook/namespace_validation.py
@@ -9,50 +9,61 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("namespace-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_NAMESPACE = Counter('webhook_namespace_validation_total', 'The total number of namespace validation requests')
-DENIED_NAMESPACE = Counter('webhook_namespace_validation_denied', 'The total number of namespace validation requests denied')
+TOTAL_NAMESPACE = Counter(
+    "webhook_namespace_validation_total",
+    "The total number of namespace validation requests",
+)
+DENIED_NAMESPACE = Counter(
+    "webhook_namespace_validation_denied",
+    "The total number of namespace validation requests denied",
+)
 
 
-@bp.route('/namespace-validation', methods=['POST'])
+@bp.route("/namespace-validation", methods=["POST"])
 def handle_request():
-  # inc total namespace counter
-  TOTAL_NAMESPACE.inc()
-  debug = os.getenv("DEBUG_NAMESPACE_VALIDATION", "False")
-  debug = (debug == "True")
+    # inc total namespace counter
+    TOTAL_NAMESPACE.inc()
+    debug = os.getenv("DEBUG_NAMESPACE_VALIDATION", "False")
+    debug = debug == "True"
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+    if debug:
+        print("REQUEST BODY => {}".format(request.json))
 
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except Exception:
-    valid = False
+    valid = True
+    try:
+        valid = validate.validate_request_structure(request.json)
+    except Exception:
+        valid = False
 
-  if not valid:
-    # inc denied namespace counter
-    DENIED_NAMESPACE.inc()
-    return responses.response_invalid()
-  
-  return get_response(request, debug)
+    if not valid:
+        # inc denied namespace counter
+        DENIED_NAMESPACE.inc()
+        return responses.response_invalid()
+
+    return get_response(request, debug)
 
 
 def get_response(req, debug=False):
-  try:
-    body_dict = req.json['request']
-    requester_group_memberships = body_dict['userInfo']['groups']
-    if "dedicated-admins" in requester_group_memberships:
-      requested_ns = body_dict['namespace']
-      privileged_namespace_re = '(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$|^redhat-.*)'
-      # match will return a match object if the namespace matches the regex, or None if the namespace doesn't match the regex
-      if re.match(privileged_namespace_re, requested_ns) is not None:
-        return responses.response_deny(req=body_dict, msg="You cannot update the privileged namespace {}.".format(requested_ns))
-      else:
-        return responses.response_allow(req=body_dict)
-    else:
-      return responses.response_allow(req=body_dict)
-  except Exception:
-    print("Exception:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+    try:
+        body_dict = req.json["request"]
+        requester_group_memberships = body_dict["userInfo"]["groups"]
+        if "dedicated-admins" in requester_group_memberships:
+            requested_ns = body_dict["namespace"]
+            privileged_namespace_re = "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$|^redhat-.*)"
+            # match will return a match object if the namespace matches the regex, or None if the namespace doesn't match the regex
+            if re.match(privileged_namespace_re, requested_ns) is not None:
+                return responses.response_deny(
+                    req=body_dict,
+                    msg="You cannot update the privileged namespace {}.".format(
+                        requested_ns
+                    ),
+                )
+            else:
+                return responses.response_allow(req=body_dict)
+        else:
+            return responses.response_allow(req=body_dict)
+    except Exception:
+        print("Exception:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()

--- a/src/webhook/regular_user_validation.py
+++ b/src/webhook/regular_user_validation.py
@@ -7,70 +7,77 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("regular-user-webhook", __name__)
 
 # the groups allowed to administer resources in cluster (i.e. exempt from this webhook)
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins")
+admin_group = os.getenv(
+    "GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins"
+)
 
 admin_groups = admin_group.split(",")
 
 
-@bp.route('/regular-user-validation', methods=['POST'])
+@bp.route("/regular-user-validation", methods=["POST"])
 def handle_request():
-  debug = os.getenv("DEBUG_REGULAR_USER_DENIER", "False")
-  debug = (debug == "True")
+    debug = os.getenv("DEBUG_REGULAR_USER_DENIER", "False")
+    debug = debug == "True"
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+    if debug:
+        print("REQUEST BODY => {}".format(request.json))
 
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except Exception:
-    valid = False
+    valid = True
+    try:
+        valid = validate.validate_request_structure(request.json)
+    except Exception:
+        valid = False
 
-  if not valid:
-    return responses.response_invalid()
-  
-  return get_response(request, debug)
+    if not valid:
+        return responses.response_invalid()
+
+    return get_response(request, debug)
 
 
 def get_response(req, debug=False):
-  if debug:
-    print("REQUEST BODY => {}".format(req.json))
+    if debug:
+        print("REQUEST BODY => {}".format(req.json))
 
-  try:
-    body_dict = req.json['request']
-    username = body_dict['userInfo']['username']
-    groups = body_dict['userInfo']['groups']
+    try:
+        body_dict = req.json["request"]
+        username = body_dict["userInfo"]["username"]
+        groups = body_dict["userInfo"]["groups"]
 
-    if is_request_allowed(username, groups, admin_groups):
-      return responses.response_allow(req=body_dict)
-    else:
-      if body_dict['object'] is None:
-        kind = body_dict['oldObject']['kind']
-      else:
-        kind = body_dict['object']['kind']
-      operation = body_dict['operation']
-      return responses.response_deny(req=body_dict, msg="Regular user '{}' cannot {} kind '{}'.".format(username, operation, kind))
-  except Exception:
-    print("Exception:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+        if is_request_allowed(username, groups, admin_groups):
+            return responses.response_allow(req=body_dict)
+        else:
+            if body_dict["object"] is None:
+                kind = body_dict["oldObject"]["kind"]
+            else:
+                kind = body_dict["object"]["kind"]
+            operation = body_dict["operation"]
+            return responses.response_deny(
+                req=body_dict,
+                msg="Regular user '{}' cannot {} kind '{}'.".format(
+                    username, operation, kind
+                ),
+            )
+    except Exception:
+        print("Exception:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()
 
 
 def is_request_allowed(username, groups, admin_groupnames=()):
-  """Decide if it's a special user (SA, kube:admin, etc) or not.
+    """Decide if it's a special user (SA, kube:admin, etc) or not.
 
   reference: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request
   """
-  # unauthenticated is DENY
-  if username == "system:unauthenticated":
+    # unauthenticated is DENY
+    if username == "system:unauthenticated":
+        return False
+    # system users is ALLOW
+    if username.startswith("kube:") or username.startswith("system:"):
+        return True
+    # SRE groups are ALLOW
+    for group in groups:
+        if group in admin_groupnames:
+            return True
+    # else DENY
     return False
-  # system users is ALLOW
-  if username.startswith("kube:") or username.startswith("system:"):
-    return True
-  # SRE groups are ALLOW
-  for group in groups:
-    if group in admin_groupnames:
-      return True
-  # else DENY
-  return False

--- a/src/webhook/request_helper/responses.py
+++ b/src/webhook/request_helper/responses.py
@@ -2,28 +2,30 @@ import json
 import os
 
 
-def response_base(req, allowed, msg=''):
+def response_base(req, allowed, msg=""):
     body = {
-        'apiVersion': 'admission.k8s.io/v1beta1',
-        'kind': 'AdmissionReview',
-        'response': {
-            'uid': req['uid'],
-            'allowed': allowed,
-            'status': {
-                'message': msg
-            }
-        }
+        "apiVersion": "admission.k8s.io/v1beta1",
+        "kind": "AdmissionReview",
+        "response": {"uid": req["uid"], "allowed": allowed, "status": {"message": msg}},
     }
     return json.dumps(body)
 
 
 def response_allow(req, msg="Allowed resource for this cluster"):
-    print("[pid={}] Allowing admission {}: {}".format(os.getpid(), req['userInfo']['username'], msg))
+    print(
+        "[pid={}] Allowing admission {}: {}".format(
+            os.getpid(), req["userInfo"]["username"], msg
+        )
+    )
     return response_base(req=req, allowed=True, msg="Access granted")
 
 
 def response_deny(req, msg="Prohibited resource for this cluster"):
-    print("[pid={}] Denying admission {}: {}".format(os.getpid(), req['userInfo']['username'], msg))
+    print(
+        "[pid={}] Denying admission {}: {}".format(
+            os.getpid(), req["userInfo"]["username"], msg
+        )
+    )
     return response_base(req=req, allowed=False, msg=msg)
 
 

--- a/src/webhook/request_helper/validate.py
+++ b/src/webhook/request_helper/validate.py
@@ -1,11 +1,11 @@
 def validate_request_structure(request_json):
-  """Validate the request structure.
+    """Validate the request structure.
   """
 
-  doc_keys = request_json.keys()
+    doc_keys = request_json.keys()
 
-  if 'kind' not in doc_keys:
+    if "kind" not in doc_keys:
+        return False
+    if request_json["kind"] == "AdmissionReview":
+        return True
     return False
-  if request_json['kind'] == "AdmissionReview":
-    return True
-  return False

--- a/src/webhook/subscription_validation.py
+++ b/src/webhook/subscription_validation.py
@@ -7,46 +7,62 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("subscription-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_SUBSCRIPTION = Counter('webhook_subscription_validation_total', 'The total number of subscription validation requests')
-DENIED_SUBSCRIPTION = Counter('webhook_subscription_validation_denied', 'The total number of subscription validation requests denied')
+TOTAL_SUBSCRIPTION = Counter(
+    "webhook_subscription_validation_total",
+    "The total number of subscription validation requests",
+)
+DENIED_SUBSCRIPTION = Counter(
+    "webhook_subscription_validation_denied",
+    "The total number of subscription validation requests denied",
+)
 
-valid_source_namespaces = os.getenv("SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace")
+valid_source_namespaces = os.getenv(
+    "SUBSCRIPTION_VALIDATION_NAMESPACES", "openshift-marketplace"
+)
 valid_source_namespaces = valid_source_namespaces.split(",")
 
 
-@bp.route('/subscription-validation', methods=['POST'])
+@bp.route("/subscription-validation", methods=["POST"])
 def handle_request():
-  # inc total subscription counter
-  TOTAL_SUBSCRIPTION.inc()
-  debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
-  debug = (debug == "True")
+    # inc total subscription counter
+    TOTAL_SUBSCRIPTION.inc()
+    debug = os.getenv("DEBUG_SUBSCRIPTION_VALIDATION", "False")
+    debug = debug == "True"
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+    if debug:
+        print("REQUEST BODY => {}".format(request.json))
 
-  valid = True
-  try:
-    valid = validate.validate_request_structure(request.json)
-  except Exception:
-    valid = False
+    valid = True
+    try:
+        valid = validate.validate_request_structure(request.json)
+    except Exception:
+        valid = False
 
-  if not valid:
-    # inc denied subscription counter
-    DENIED_SUBSCRIPTION.inc()
-    return responses.response_invalid()
-  
-  try:
-    body_dict = request.json['request']
-    requester_group_memberships = body_dict['userInfo']['groups']
-    if "dedicated-admins" in requester_group_memberships:
-      if body_dict['object']['spec']['sourceNamespace'] not in valid_source_namespaces:
-        return responses.response_deny(req=body_dict, msg="You cannot manage Subscriptions that target {}.".format(body_dict['object']['spec']['sourceNamespace']))
-      else:
-        return responses.response_allow(req=body_dict)
-    else:
-      return responses.response_allow(req=body_dict)
-  except Exception:
-    print("Exception:")
-    print("-" * 60)
-    traceback.print_exc(file=sys.stdout)
-    return responses.response_invalid()
+    if not valid:
+        # inc denied subscription counter
+        DENIED_SUBSCRIPTION.inc()
+        return responses.response_invalid()
+
+    try:
+        body_dict = request.json["request"]
+        requester_group_memberships = body_dict["userInfo"]["groups"]
+        if "dedicated-admins" in requester_group_memberships:
+            if (
+                body_dict["object"]["spec"]["sourceNamespace"]
+                not in valid_source_namespaces
+            ):
+                return responses.response_deny(
+                    req=body_dict,
+                    msg="You cannot manage Subscriptions that target {}.".format(
+                        body_dict["object"]["spec"]["sourceNamespace"]
+                    ),
+                )
+            else:
+                return responses.response_allow(req=body_dict)
+        else:
+            return responses.response_allow(req=body_dict)
+    except Exception:
+        print("Exception:")
+        print("-" * 60)
+        traceback.print_exc(file=sys.stdout)
+        return responses.response_invalid()

--- a/src/webhook/test_identity_validation.py
+++ b/src/webhook/test_identity_validation.py
@@ -3,9 +3,7 @@ import json
 
 from webhook.identity_validation import get_response
 
-ADMIN_GROUPS = [
-    "osd-sre-admins"
-]
+ADMIN_GROUPS = ["osd-sre-admins"]
 
 
 def create_request(username, groups, identityName, providerName):
@@ -15,17 +13,12 @@ def create_request(username, groups, identityName, providerName):
                 "request": {
                     "uid": "testuser",
                     "operation": "UPDATE",
-                    "userInfo": {
-                        "groups": groups,
-                        "username": username,
-                    },
+                    "userInfo": {"groups": groups, "username": username,},
                     "object": {
                         "kind": "Identity",
-                        "metadata": {
-                            "name": identityName
-                        },
-                        "providerName": providerName
-                    }
+                        "metadata": {"name": identityName},
+                        "providerName": providerName,
+                    },
                 }
             }
 
@@ -36,10 +29,8 @@ def create_request(username, groups, identityName, providerName):
 
 
 class TestIdentityValidation(unittest.TestCase):
-
     def runtests(self, username, testGroups, identityName, providerName):
-        request = create_request(username, testGroups,
-                                 identityName, providerName)
+        request = create_request(username, testGroups, identityName, providerName)
 
         response = json.loads(get_response(request, debug=False))
         return response
@@ -47,41 +38,51 @@ class TestIdentityValidation(unittest.TestCase):
     # oauth ServiceAccount can update redhat user identity
     def test_oauth_sa(self):
         response = self.runtests(
-            "system:serviceaccount:openshift-authentication:oauth-openshift", "", "OpenShift_SRE:test", "OpenShift_SRE")
-        self.assertTrue(response['response']['allowed'])
+            "system:serviceaccount:openshift-authentication:oauth-openshift",
+            "",
+            "OpenShift_SRE:test",
+            "OpenShift_SRE",
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # system:admin can update redhat user identity
     def test_system_admin(self):
         response = self.runtests(
-            "system:admin", "", "OpenShift_SRE:test", "OpenShift_SRE")
-        self.assertTrue(response['response']['allowed'])
+            "system:admin", "", "OpenShift_SRE:test", "OpenShift_SRE"
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # kube:admin can update redhat user identity
     def test_kube_admin(self):
         response = self.runtests(
-            "kube:admin", "", "OpenShift_SRE:test", "OpenShift_SRE")
-        self.assertTrue(response['response']['allowed'])
+            "kube:admin", "", "OpenShift_SRE:test", "OpenShift_SRE"
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # users in sre admin groups can update redhat user identity
     def test_sre_groups(self):
         response = self.runtests(
-            "test@redhat.com", ADMIN_GROUPS, "OpenShift_SRE:test", "OpenShift_SRE")
-        self.assertTrue(response['response']['allowed'])
+            "test@redhat.com", ADMIN_GROUPS, "OpenShift_SRE:test", "OpenShift_SRE"
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # dedicated-admins can update custom user identity
     def test_ded_admins_custom_user(self):
         response = self.runtests(
-            "test@customdomain", "dedicated-admins", "CUSTOM:test", "CUSTOM")
-        self.assertTrue(response['response']['allowed'])
+            "test@customdomain", "dedicated-admins", "CUSTOM:test", "CUSTOM"
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # dedicated-admins cannot update redhat user identity
     def test_ded_admins_redhat_user(self):
         response = self.runtests(
-            "customer@custom", "dedicated-admins", "OpenShift_SRE:test", "OpenShift_SRE")
-        self.assertFalse(response['response']['allowed'])
+            "customer@custom", "dedicated-admins", "OpenShift_SRE:test", "OpenShift_SRE"
+        )
+        self.assertFalse(response["response"]["allowed"])
 
     # users in sre admin groups can update redhat user identity
     def test_sre_update_custom_user(self):
         response = self.runtests(
-            "test@redhat.com", ADMIN_GROUPS, "CUSTOM:test", "CUSTOM")
-        self.assertTrue(response['response']['allowed'])
+            "test@redhat.com", ADMIN_GROUPS, "CUSTOM:test", "CUSTOM"
+        )
+        self.assertTrue(response["response"]["allowed"])

--- a/src/webhook/test_namespace_validation.py
+++ b/src/webhook/test_namespace_validation.py
@@ -55,10 +55,7 @@ def create_request(namespace, groups):
         json = {
             "request": {
                 "uid": "testuser",
-                "userInfo": {
-                    "username": "me",
-                    "groups": groups,
-                },
+                "userInfo": {"username": "me", "groups": groups,},
                 "namespace": namespace,
             }
         }
@@ -69,19 +66,18 @@ def create_request(namespace, groups):
 class TestNamespaceValidation(unittest.TestCase):
     def runtest(self, namespace, groups, expect):
         # Make test failures easier to identify
-        failmsg = "expect={}, namespace={}, groups={}".format(
-            expect, namespace, groups)
+        failmsg = "expect={}, namespace={}, groups={}".format(expect, namespace, groups)
         request = create_request(namespace, groups)
         response = namespace_validation.get_response(request)
-        response = json.loads(response)['response']
-        self.assertEqual(expect, response['allowed'], failmsg)
+        response = json.loads(response)["response"]
+        self.assertEqual(expect, response["allowed"], failmsg)
         # On DENY, validate the status message
         if not expect:
             self.assertEqual(
-                "You cannot update the privileged namespace {}.".format(
-                    namespace),
-                response['status']['message'],
-                failmsg)
+                "You cannot update the privileged namespace {}.".format(namespace),
+                response["status"]["message"],
+                failmsg,
+            )
 
     def test_deny(self):
         # In order to get DENYs, we must have *both* a privileged namespace
@@ -89,7 +85,7 @@ class TestNamespaceValidation(unittest.TestCase):
         for ns in PRIVILEGED_NAMESPACES:
             for gl in GROUP_LISTS:
                 # Always include dedicated-admins
-                groups = gl + ('dedicated-admins',)
+                groups = gl + ("dedicated-admins",)
                 self.runtest(ns, groups, False)
 
     def test_allow_group(self):
@@ -105,16 +101,16 @@ class TestNamespaceValidation(unittest.TestCase):
         for ns in NONPRIV_NAMESPACES:
             for gl in GROUP_LISTS:
                 self.runtest(ns, gl, True)
-                groups = gl + ('dedicated-admins',)
+                groups = gl + ("dedicated-admins",)
                 self.runtest(ns, groups, True)
 
     def test_invalid(self):
         # Validate the exception path
-        request = create_request('foo', [])
+        request = create_request("foo", [])
         # This will trigger a KeyError when get_response tries to access the
         # 'userInfo'
-        del request.json['request']['userInfo']
+        del request.json["request"]["userInfo"]
         response = namespace_validation.get_response(request)
         self.assertEqual(
-            "Invalid request",
-            json.loads(response)['response']['status']['message'])
+            "Invalid request", json.loads(response)["response"]["status"]["message"]
+        )

--- a/src/webhook/test_regular_user_validation.py
+++ b/src/webhook/test_regular_user_validation.py
@@ -4,9 +4,7 @@ import json
 from webhook.regular_user_validation import is_request_allowed
 from webhook.regular_user_validation import get_response
 
-ADMIN_GROUPS = [
-    "osd-sre-admins"
-]
+ADMIN_GROUPS = ["osd-sre-admins"]
 
 
 def create_request(username, groups):
@@ -16,13 +14,8 @@ def create_request(username, groups):
                 "request": {
                     "uid": "testuser",
                     "operation": "UPDATE",
-                    "userInfo": {
-                        "username": username,
-                        "groups": groups,
-                    },
-                    "object": {
-                        "kind": "TestResources",
-                    }
+                    "userInfo": {"username": username, "groups": groups,},
+                    "object": {"kind": "TestResources",},
                 }
             }
 
@@ -39,9 +32,9 @@ class TestRegularUserValidation_Unauthenticated(unittest.TestCase):
         self.assertFalse(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
-        
+
         response = json.loads(get_response(request, debug=False))
-        self.assertFalse(response['response']['allowed'])
+        self.assertFalse(response["response"]["allowed"])
 
     def test_noGroup(self):
         self.runtests([])
@@ -66,9 +59,9 @@ class TestRegularUserValidation_kubeadmin(unittest.TestCase):
         self.assertTrue(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
-        
+
         response = json.loads(get_response(request, debug=False))
-        self.assertTrue(response['response']['allowed'])
+        self.assertTrue(response["response"]["allowed"])
 
     def test_noGroup(self):
         self.runtests([])
@@ -93,9 +86,9 @@ class TestRegularUserValidation_systemadmin(unittest.TestCase):
         self.assertTrue(is_request_allowed(self.username, testGroups, ADMIN_GROUPS))
 
         request = create_request(self.username, testGroups)
-        
+
         response = json.loads(get_response(request, debug=False))
-        self.assertTrue(response['response']['allowed'])
+        self.assertTrue(response["response"]["allowed"])
 
     def test_noGroup(self):
         self.runtests([])
@@ -124,7 +117,7 @@ class TestRegularUserValidation_sreUser(unittest.TestCase):
 
         request = create_request(self.username, testGroups)
         response = json.loads(get_response(request, debug=False))
-        self.assertTrue(response['response']['allowed'])
+        self.assertTrue(response["response"]["allowed"])
 
     def test_noGroup(self):
         self.runtests([])
@@ -150,7 +143,7 @@ class TestRegularUserValidation_nonSreGroup(unittest.TestCase):
 
         request = create_request(self.username, testGroups)
         response = json.loads(get_response(request, debug=False))
-        self.assertFalse(response['response']['allowed'])
+        self.assertFalse(response["response"]["allowed"])
 
     def test_noGroup(self):
         self.runtests([])

--- a/src/webhook/test_user_validation.py
+++ b/src/webhook/test_user_validation.py
@@ -3,9 +3,7 @@ import json
 
 from webhook.user_validation import get_response
 
-ADMIN_GROUPS = [
-    "osd-sre-admins"
-]
+ADMIN_GROUPS = ["osd-sre-admins"]
 
 
 def create_request(username, groups, objectName):
@@ -15,16 +13,8 @@ def create_request(username, groups, objectName):
                 "request": {
                     "uid": "testuser",
                     "operation": "UPDATE",
-                    "userInfo": {
-                        "groups": groups,
-                        "username": username,
-                    },
-                    "object": {
-                        "kind": "User",
-                        "metadata": {
-                            "name": objectName,
-                        }
-                    }
+                    "userInfo": {"groups": groups, "username": username,},
+                    "object": {"kind": "User", "metadata": {"name": objectName,}},
                 }
             }
 
@@ -35,7 +25,6 @@ def create_request(username, groups, objectName):
 
 
 class TestUserValidation(unittest.TestCase):
-
     def runtests(self, username, testGroups, objectName):
         request = create_request(username, testGroups, objectName)
 
@@ -45,41 +34,42 @@ class TestUserValidation(unittest.TestCase):
     # oauth ServiceAccount can update redhat users
     def test_oauth_sa(self):
         response = self.runtests(
-            "system:serviceaccount:openshift-authentication:oauth-openshift", "", "test@redhat.com")
-        self.assertTrue(response['response']['allowed'])
+            "system:serviceaccount:openshift-authentication:oauth-openshift",
+            "",
+            "test@redhat.com",
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # system:admin can update redhat users
     def test_system_admin(self):
-        response = self.runtests(
-            "system:admin", "", "test@redhat.com")
-        self.assertTrue(response['response']['allowed'])
+        response = self.runtests("system:admin", "", "test@redhat.com")
+        self.assertTrue(response["response"]["allowed"])
 
     # kube:admin can update redhat users
     def test_kube_admin(self):
-        response = self.runtests(
-            "kube:admin", "", "test@redhat.com")
-        self.assertTrue(response['response']['allowed'])
+        response = self.runtests("kube:admin", "", "test@redhat.com")
+        self.assertTrue(response["response"]["allowed"])
 
     # users in sre admin groups can update redhat users
     def test_sre_groups(self):
-        response = self.runtests(
-            "test@redhat.com", ADMIN_GROUPS, "test@redhat.com")
-        self.assertTrue(response['response']['allowed'])
+        response = self.runtests("test@redhat.com", ADMIN_GROUPS, "test@redhat.com")
+        self.assertTrue(response["response"]["allowed"])
 
     # dedicated-admins can update custom users
     def test_ded_admins_custom_user(self):
         response = self.runtests(
-            "test@customdomain", "dedicated-admins", "test1@customdomain")
-        self.assertTrue(response['response']['allowed'])
+            "test@customdomain", "dedicated-admins", "test1@customdomain"
+        )
+        self.assertTrue(response["response"]["allowed"])
 
     # dedicated-admins cannot update redhat users
     def test_ded_admins_redhat_user(self):
         response = self.runtests(
-            "customer@custom", "dedicated-admins", "test@redhat.com")
-        self.assertFalse(response['response']['allowed'])
+            "customer@custom", "dedicated-admins", "test@redhat.com"
+        )
+        self.assertFalse(response["response"]["allowed"])
 
     # users in sre admin groups can update redhat user
     def test_sre_update_custom_user(self):
-        response = self.runtests(
-            "test@redhat.com", ADMIN_GROUPS, "test@customdomain")
-        self.assertTrue(response['response']['allowed'])
+        response = self.runtests("test@redhat.com", ADMIN_GROUPS, "test@customdomain")
+        self.assertTrue(response["response"]["allowed"])

--- a/src/webhook/user_validation.py
+++ b/src/webhook/user_validation.py
@@ -8,24 +8,28 @@ from webhook.request_helper import validate, responses
 bp = Blueprint("user-webhook", __name__)
 
 # define what we track, declare Counter, how many times this route is accessed
-TOTAL_USER = Counter('webhook_user_validation_total',
-                     'The total number of user validation requests')
-DENIED_USER = Counter('webhook_user_validation_denied',
-                      'The total number of user validation requests denied')
+TOTAL_USER = Counter(
+    "webhook_user_validation_total", "The total number of user validation requests"
+)
+DENIED_USER = Counter(
+    "webhook_user_validation_denied",
+    "The total number of user validation requests denied",
+)
 
 protected_user_suffix = "@redhat.com"
 
-admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP",
-                        "osd-sre-admins,osd-sre-cluster-admins")
+admin_group = os.getenv(
+    "GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins"
+)
 admin_groups = admin_group.split(",")
 
 
-@bp.route('/user-validation', methods=['POST'])
+@bp.route("/user-validation", methods=["POST"])
 def handle_request():
     # inc total user counter
     TOTAL_USER.inc()
     debug = os.getenv("DEBUG_USER_VALIDATION", "False")
-    debug = (debug == "True")
+    debug = debug == "True"
 
     if debug:
         print("REQUEST BODY => {}".format(request.json))
@@ -46,31 +50,43 @@ def handle_request():
 
 def get_response(request, debug=False):
     try:
-        body_dict = request.json['request']
+        body_dict = request.json["request"]
         # If trying to delete a user, must get user name from oldObject instead of object
-        if body_dict['object'] is None:
-            user_name = body_dict['oldObject']['metadata']['name']
+        if body_dict["object"] is None:
+            user_name = body_dict["oldObject"]["metadata"]["name"]
         else:
-            user_name = body_dict['object']['metadata']['name']
-        userinfo = body_dict['userInfo']
-        if userinfo['username'] in ("kube:admin", "system:admin", "system:serviceaccount:openshift-authentication:oauth-openshift"):
+            user_name = body_dict["object"]["metadata"]["name"]
+        userinfo = body_dict["userInfo"]
+        if userinfo["username"] in (
+            "kube:admin",
+            "system:admin",
+            "system:serviceaccount:openshift-authentication:oauth-openshift",
+        ):
             # kube/system admin, oauth service accounts can do anything
             if debug:
-                print("Performing action: {} on user {} by {}".format(
-                    body_dict['operation'], user_name, userinfo['username']))
+                print(
+                    "Performing action: {} on user {} by {}".format(
+                        body_dict["operation"], user_name, userinfo["username"]
+                    )
+                )
             return responses.response_allow(req=body_dict)
         if user_name.endswith(protected_user_suffix):
             if debug:
-                print("Performing action: {} on {} user".format(
-                    body_dict['operation'], user_name))
-            if len(set(userinfo['groups']) & set(admin_groups)) > 0:
+                print(
+                    "Performing action: {} on {} user".format(
+                        body_dict["operation"], user_name
+                    )
+                )
+            if len(set(userinfo["groups"]) & set(admin_groups)) > 0:
                 response_body = responses.response_allow(
-                    req=body_dict, msg="{} user {}".format(body_dict['operation'], user_name))
+                    req=body_dict,
+                    msg="{} user {}".format(body_dict["operation"], user_name),
+                )
             else:
                 deny_msg = "User not authorized to {} user {}".format(
-                    body_dict['operation'], user_name)
-                response_body = responses.response_deny(
-                    req=body_dict, msg=deny_msg)
+                    body_dict["operation"], user_name
+                )
+                response_body = responses.response_deny(req=body_dict, msg=deny_msg)
                 DENIED_USER.inc()
         else:
             response_body = responses.response_allow(req=body_dict)
@@ -78,8 +94,11 @@ def get_response(request, debug=False):
             print("Response body => {}".format(response_body))
         return response_body
     except Exception:
-        print("Exception when trying to access attributes. Request body: {}".format(
-            request.json))
+        print(
+            "Exception when trying to access attributes. Request body: {}".format(
+                request.json
+            )
+        )
         print("Backtrace:")
         print("-" * 60)
         traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
This switches from `flake8` to [black](https://github.com/psf/black)
linting, including adding a `black` make target you can run to get your
code compliant.

This is in the same spirit as how other projects lint go code:
- Like `gofmt`, `black` is highly opinionated.
- Like `gofmt`, `black` has the ability to reformat and rewrite code in
place. But
- Like our projects that lint-check go with `gofmt`, we run this in
advisory mode and simply fail the build if there are deviations from
what `black` wants, whereupon
- Like our projects that lint-check go with `gofmt`, it is the
committer's responsibility to run `black` in overwrite mode (which can
be done via `make black`) and commit the changes in order to pass the
build.