### PR TITLE
Move flake8 options to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,7 @@ test-container:
 
 .PHONY: lint
 lint: test-container
-	# E111 indentation is not a multiple of four
-	# E121 continuation line under-indented for hanging indent
-	# E401 multiple imports on one line
-	# E402 module level import not at top of file
-	# E501 line too long (N > 79 characters)
-	# E722 do not use bare 'except'
-	# W293 blank line contains whitespace
-	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; flake8 --ignore E111,E121,E114,E401,E402,E501,E722,W293 src/"
+	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; flake8 --config src/flake8.ini src/"
 
 .PHONY: test
 test: test-container

--- a/src/flake8.ini
+++ b/src/flake8.ini
@@ -1,0 +1,10 @@
+# TODO: centralize this
+[flake8]
+# E111 indentation is not a multiple of four
+# E121 continuation line under-indented for hanging indent
+# E401 multiple imports on one line
+# E402 module level import not at top of file
+# E501 line too long (N > 79 characters)
+# E722 do not use bare 'except'
+# W293 blank line contains whitespace
+ignore = E111,E121,E114,E401,E402,E501,E722,W293


### PR DESCRIPTION
This is a straight refactor of the `lint` target to move the flake8
options from the command line into a config file. This makes it easier
to document and change them, and will make it easier to centralize this
configuration across multiple projects once we've decided on a common
standard.