### PR TITLE
:bug: When pwd involves a symlink, test, build-sss, lint fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,15 +41,15 @@ lint: test-container
 	# E501 line too long (N > 79 characters)
 	# E722 do not use bare 'except'
 	# W293 blank line contains whitespace
-	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; flake8 --ignore E111,E121,E114,E401,E402,E501,E722,W293 src/"
+	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd -P`; flake8 --ignore E111,E121,E114,E401,E402,E501,E722,W293 src/"
 
 .PHONY: test
 test: test-container
-	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; ./hack/test.sh"
+	$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd -P`; ./hack/test.sh"
 
 .PHONY: build-sss
 build-sss: render test-container
-	${CONTAINER_ENGINE} run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd`; python build/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -b ${BUILD_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
+	${CONTAINER_ENGINE} run --rm -v `pwd -P`:`pwd -P` $(REPO_NAME):test /bin/sh -c "cd `pwd -P`; python build/generate_syncset.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -b ${BUILD_DIRECTORY} -d ${SELECTOR_SYNC_SET_DESTINATION} -r ${REPO_NAME}"
 
 .PHONY: build-base
 build-base: lint test build/Dockerfile


### PR DESCRIPTION
When `pwd` includes a symlink, the `test`, `build-sss` and `lint` make targets fail because even though the correct volume is mounted (with `-v` and using `pwd -P`), the "cd" inside the container does not respect it, and so will try to `cd` to the wrong place.