### PR TITLE
CSSRE-998: Added support for protecting exclusive groups.

### DIFF
--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -7,6 +7,8 @@ from webhook.request_helper import validate, responses
 
 bp = Blueprint("group-webhook", __name__)
 
+DEBUG = os.getenv("DEBUG_GROUP_VALIDATION", "False")
+
 # define what we track, declare Counter, how many times this route is accessed
 TOTAL_GROUP = Counter('webhook_group_validation_total', 'The total number of group validation requests')
 DENIED_GROUP = Counter('webhook_group_validation_denied', 'The total number of group validation requests denied')
@@ -18,16 +20,24 @@ admin_groups = admin_group.split(",")
 # groups that cannot be edited by non-admins
 protected_group_regex = os.getenv("GROUP_VALIDATION_PROTECTED_GROUP_REGEX", "(^osd-sre.*|^dedicated-admins$|^cluster-admins$|^layered-cs-sre-admins$)")
 
+exclusive_group_prefixes = os.getenv("GROUP_VALIDATION_EXCLUSIVE_GROUP_PREFIXES", "").split(",")
+
+
+def log_debug(msg):
+  if DEBUG:
+    print(msg)
+
+
+def log(msg):
+  print(msg)
+
 
 @bp.route('/group-validation', methods=['POST'])
 def handle_request():
   # inc total group counter
   TOTAL_GROUP.inc()
-  debug = os.getenv("DEBUG_GROUP_VALIDATION", "False")
-  debug = (debug == "True")
 
-  if debug:
-    print("REQUEST BODY => {}".format(request.json))
+  log_debug("REQUEST BODY => {}".format(request.json))
 
   valid = True
   try:
@@ -40,10 +50,13 @@ def handle_request():
     DENIED_GROUP.inc()
     return responses.response_invalid()
 
-  return get_response(request, debug)
+  return get_response(
+    request, 
+    exclusive_group_prefixes=exclusive_group_prefixes
+  )
 
 
-def get_response(req, debug=False):
+def get_response(req, exclusive_group_prefixes=[]):
   try:
     body_dict = req.json['request']
     # If trying to delete a group, must get group name from oldObject instead of object
@@ -65,30 +78,65 @@ def get_response(req, debug=False):
 
     if user_name in ("kube:admin", "system:admin"):
       # kube/system admin can do anything
-      if debug:
-        print("Performing action: {} in {} group for {}".format(body_dict['operation'], group_name, userinfo['username']))
+      log_debug("Performing action: {} in {} group for {}".format(body_dict['operation'], group_name, userinfo['username']))
       return responses.response_allow(req=body_dict)
 
     if re.match(protected_group_regex, group_name) is not None:
       # attempted operation on a protected group
-      if debug:
-        print("Performing action: {} in {} group".format(body_dict['operation'], group_name))
+      log_debug("Performing action: {} in {} group".format(body_dict['operation'], group_name))
+    
+      deny_msg = "User not authorized to {} group {}".format(
+          body_dict['operation'], group_name)
+
+      exclusive_prefix = match_group_prefix(
+        group_name, 
+        exclusive_group_prefixes
+      )
+      user_groups_prefixes = match_group_list_prefix(
+          user_groups, [exclusive_prefix])    
+
       if len(set(user_groups) & set(admin_groups)) > 0:
-        # user is a member of admin groups, this is allowed
-        response_body = responses.response_allow(req=body_dict, msg="{} group {}".format(body_dict['operation'], group_name))
+        
+        if exclusive_prefix and not user_groups_prefixes:
+          log_debug(('Operations on group "{}" are exclusive only to users in '
+                   'groups with prefix "{}"').format(group_name, exclusive_prefix))
+          response_body = responses.response_deny(req=body_dict, msg=deny_msg)
+        else:
+          # user is a member of admin groups, this is allowed
+          response_body = responses.response_allow(
+          req=body_dict, 
+          msg="{} group {}".format(body_dict['operation'], group_name)
+      )
       else:
         # user is NOT a member of admin groups, this is denied
-        deny_msg = "User not authorized to {} group {}".format(body_dict['operation'], group_name)
         response_body = responses.response_deny(req=body_dict, msg=deny_msg)
     else:
       # was not a protected group, so we can let it through
       response_body = responses.response_allow(req=body_dict)
-    if debug:
-      print("Response body => {}".format(response_body))
+    
+    log_debug("Response body => {}".format(response_body))
     return response_body
   except Exception:
-    print("Exception when trying to access attributes. Request body: {}".format(req.json))
-    print("Backtrace:")
-    print("-" * 60)
+    log("Exception when trying to access attributes. Request body: {}".format(req.json))
+    log("Backtrace:")
+    log("-" * 60)
     traceback.print_exc(file=sys.stdout)
     return responses.response_invalid()
+
+
+def match_group_prefix(group, group_prefixes):
+  """Returns the first match of a group prefix in a list of group prefixes"""
+  for prefix in group_prefixes:
+    if prefix and len(prefix) and group.startswith(prefix):
+      return prefix
+
+
+def match_group_list_prefix(group_list, group_prefixes):
+  """Returns a list of matched group prefixes from a list of group prefixes"""
+  prefixes = []
+  for group in group_list:
+    prefix = match_group_prefix(group, group_prefixes)
+    if prefix:
+      prefixes.append(prefix)
+  return prefixes
+  


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/CSSRE-988

**Problem**
Some "exclusive" groups (see jira) are not protected by the group validation. For example, currently, there is no way to enforce that a group `my-group-a` can only be operated on (create, update, delete) by a user that is a member of a group with prefix `my-group`.

> Note that the DONE requirements are in Jira, please have a look for the specific group examples.

**Solution**
- Introduced an env var `GROUP_VALIDATION_EXCLUSIVE_GROUP_PREFIXES` that will be used to specify a list of "exclusive" groups.
- Added additional check to disallow user from performing operations to exclusive groups if he/she isn't not a member of a group that has the prefix inlcuded in the env var.
- Also enhanced the readability of some code (e.g. debug)

**Test**
- A unit test is added in `test_group_validation.test_exclusive_group` to ensure the new logic
- All tests passed, if needed I can attach the logs
- The tests can be simulated at unit-test-level, therefore I have not tested this in an OSD cluster as it will probably take so much effort just to test a simple logic.

Notes
- Creating a new webhook would also involve so much unnecessary effort
- The env var will need to be updated for the pods/deployment to be able to use this feature
- Note that this specific check is on top of the existing logic. This will also disallow even admins to operate on exclusive groups (as literally described in Jira)