### PR TITLE
OSD-4110: Remove IMAGE="$IMAGE" in build script

### DIFF
--- a/build/build_deploy.sh
+++ b/build/build_deploy.sh
@@ -5,4 +5,4 @@
 set -exv
 
 # build the image, the selectorsyncset, and push the image
-make -C $(dirname $0)/../ IMAGETAG="$IMAGETAG" syncset build-base skopeo-push
+make -C $(dirname $0)/../ syncset build-base skopeo-push


### PR DESCRIPTION
This is now causing builds to be problematic.