### PR TITLE
OSD-4749: Move #96 changes to code

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -219,13 +219,10 @@ objects:
         name: regular-user-validation.managed.openshift.io
         rules:
         - apiGroups:
-          # Deny ability to manage these OCP resources:
           - autoscaling.openshift.io
           - cloudcredential.openshift.io
           - machine.openshift.io
           - admissionregistration.k8s.io
-          # Deny ability to manage SRE resources:
-          # oc get --raw /apis | jq -r '.groups[] | select(.name | contains("managed")) | .name'
           - cloudingress.managed.openshift.io
           - managed.openshift.io
           - splunkforwarder.managed.openshift.io

--- a/pkg/webhooks/regularuser/regularuser.go
+++ b/pkg/webhooks/regularuser/regularuser.go
@@ -35,7 +35,11 @@ var (
 					"machine.openshift.io",
 					"admissionregistration.k8s.io",
 					"cloudingress.managed.openshift.io",
-					"veleros.managed.openshift.io",
+					// Deny ability to manage SRE resources
+					// oc get --raw /apis | jq -r '.groups[] | select(.name | contains("managed")) | .name'
+					"managed.openshift.io",
+					"splunkforwarder.managed.openshift.io",
+					"upgrade.managed.openshift.io",
 				},
 				APIVersions: []string{"*"},
 				Resources:   []string{"*/*"},


### PR DESCRIPTION
In #96 these were made in the YAML file, they are now moved to the code
file so that syncset.go will retain them in the future.

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>