### PR TITLE
OSD-4884: admin group members can delete users with IDP mismatch

### DIFF
--- a/pkg/webhooks/user/user_test.go
+++ b/pkg/webhooks/user/user_test.go
@@ -290,6 +290,26 @@ func TestNonAdminUsers(t *testing.T) {
 			operation:       v1beta1.Delete,
 			shouldBeAllowed: true,
 		},
+		// dedicated admin can't delete privileged users (RH IDP)
+		{
+			testID:          "dedi-delete-priv",
+			subjectUserName: "no-reply@redhat.com",
+			username:        "dedicated-admin",
+			userGroups:      []string{"system:authenticated", "dedicated-admins"},
+			operation:       v1beta1.Delete,
+			identity:        testRedHatIdentity,
+			shouldBeAllowed: false,
+		},
+		// dedicated admin can't delete privileged users (other IDP)
+		{
+			testID:          "dedi-delete-redhat-using-other-idp",
+			subjectUserName: "no-reply@redhat.com",
+			username:        "dedicated-admin",
+			userGroups:      []string{"system:authenticated", "dedicated-admins"},
+			operation:       v1beta1.Delete,
+			identity:        testOtherIdentity,
+			shouldBeAllowed: false,
+		},
 	}
 	runUserTests(t, tests)
 }


### PR DESCRIPTION
Prior to the changes made in 92d168b446eb84b0284175164e524f483d092a46,
people could get a User account on cluster with an idp-group mismatch.
As part of the cleanup, we need to enable members of admin groups to
delete. This change fixes a bug with the cleanup

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>