### PR TITLE
Use net.JoinHostPort over fmt.Sprintf

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 
@@ -31,7 +32,7 @@ func main() {
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(true))
 	if !*testHooks {
-		log.Info("HTTP server running at", "listen", fmt.Sprintf("%s:%s", *listenAddress, *listenPort))
+		log.Info("HTTP server running at", "listen", net.JoiNHostPort(*listenAddress, *listenPort))
 	}
 	seen := make(map[string]bool)
 	for name, hook := range webhooks.Webhooks {
@@ -50,7 +51,7 @@ func main() {
 	}
 
 	server := &http.Server{
-		Addr: fmt.Sprintf("%s:%s", *listenAddress, *listenPort),
+		Addr: net.JoinHostPort(*listenAddress, *listenPort),
 	}
 	if *useTLS {
 		cafile, err := ioutil.ReadFile(*caCert)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(true))
 	if !*testHooks {
-		log.Info("HTTP server running at", "listen", net.JoiNHostPort(*listenAddress, *listenPort))
+		log.Info("HTTP server running at", "listen", net.JoinHostPort(*listenAddress, *listenPort))
 	}
 	seen := make(map[string]bool)
 	for name, hook := range webhooks.Webhooks {


### PR DESCRIPTION
See: https://github.com/golang/go/issues/28308, https://github.com/dominikh/go-tools/issues/358 and others.

This could be seen as a bug, but we haven't hit any ipv6 issues yet, so this is an enhancement.

Note: Change made in GitHub's editor, which doesn't gofmt, so be gentle. ;) 