### PR TITLE
Webhook for blocking pods in namespaces openshift-logging, openshift-operators and non-core mnamespaces from deploying on master and infra.

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -205,6 +205,36 @@ objects:
         annotations:
           managed.openshift.io/inject-cabundle-from: openshift-validation-webhook/webhook-cert
         creationTimestamp: null
+        name: sre-pod-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1beta1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /pod-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: pod-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - v1
+          apiVersions:
+          - '*'
+          operations:
+          - '*'
+          resources:
+          - pods
+          scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 1
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          managed.openshift.io/inject-cabundle-from: openshift-validation-webhook/webhook-cert
+        creationTimestamp: null
         name: sre-regular-user-validation
       webhooks:
       - admissionReviewVersions:

--- a/pkg/webhooks/add_pod.go
+++ b/pkg/webhooks/add_pod.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/pod"
+)
+
+func init() {
+	Register(pod.WebhookName, func() Webhook { return pod.NewWebhook() })
+}

--- a/pkg/webhooks/pod/pod.go
+++ b/pkg/webhooks/pod/pod.go
@@ -1,0 +1,187 @@
+package pod
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"sync"
+
+	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	"k8s.io/api/admission/v1beta1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName           string = "pod-validation"
+	privilegedNamespace   string = `(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)`
+	unprivilegedNamespace string = `(openshift-logging|openshift-operators)`
+)
+
+var (
+	privilegedNamespaceRe   = regexp.MustCompile(privilegedNamespace)
+	unprivilegedNamespaceRe = regexp.MustCompile(unprivilegedNamespace)
+	log                     = logf.Log.WithName(WebhookName)
+
+	scope = admissionregv1.NamespacedScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{admissionregv1.OperationAll},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"v1"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"pods"},
+				Scope:       &scope,
+			},
+		},
+	}
+)
+
+type PodWebhook struct {
+	mu sync.Mutex
+	s  runtime.Scheme
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *PodWebhook) TimeoutSeconds() int32 { return 1 }
+
+// MatchPolicy implements Webhook interface
+func (s *PodWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Name implements Webhook interface
+func (s *PodWebhook) Name() string { return WebhookName }
+
+// FailurePolicy implements Webhook interface and defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are Ignore or Fail.
+// Ignore means that an error calling the webhook is ignored and the API request is allowed to continue.
+// It's important to leave the FailurePolicy set to Ignore because otherwise the pod will fail to be created as the API request will be rejected.
+func (s *PodWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// Rules implements Webhook interface
+func (s *PodWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// GetURI implements Webhook interface
+func (s *PodWebhook) GetURI() string { return "/" + WebhookName }
+
+// SideEffects implements Webhook interface
+func (s *PodWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// Validate implements Webhook interface
+func (s *PodWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "Pod")
+
+	return valid
+}
+
+func (s *PodWebhook) renderPod(req admissionctl.Request) (*corev1.Pod, error) {
+	decoder, err := admissionctl.NewDecoder(&s.s)
+	if err != nil {
+		return nil, err
+	}
+	pod := &corev1.Pod{}
+	if len(req.OldObject.Raw) > 0 {
+		err = decoder.DecodeRaw(req.OldObject, pod)
+	} else {
+		err = decoder.DecodeRaw(req.Object, pod)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return pod, nil
+}
+
+func isRequestPrivileged(namespace string) bool {
+
+	if privilegedNamespaceRe.Match([]byte(namespace)) {
+		if unprivilegedNamespaceRe.Match([]byte(namespace)) {
+			return false
+		}
+		return true
+	}
+	return false
+
+}
+
+func (s *PodWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+	pod, err := s.renderPod(request)
+	if err != nil {
+		log.Error(err, "Couldn't render a Pod from the incoming request")
+		return admissionctl.Errored(http.StatusBadRequest, err)
+	}
+
+	// If the incoming Pod is aimed at a privileged namespace except for unprivilegedNamespace, allow it to do whatever it wants.
+	// However, if the pod is targeting a customer's namespace (aka non-privileged), then it may not tolerate certain master/infra node taints.
+	if !isRequestPrivileged(pod.ObjectMeta.GetNamespace()) {
+		for _, toleration := range pod.Spec.Tolerations {
+			if toleration.Key == "node-role.kubernetes.io/infra" && toleration.Effect == corev1.TaintEffectNoSchedule {
+				ret = admissionctl.Denied("Not allowed to schedule a pod with NoSchedule taint on infra node")
+				ret.UID = request.AdmissionRequest.UID
+				return ret
+			}
+			if toleration.Key == "node-role.kubernetes.io/infra" && toleration.Effect == corev1.TaintEffectPreferNoSchedule {
+				ret = admissionctl.Denied("Not allowed to schedule a pod with PreferNoSchedule taint on infra node")
+				ret.UID = request.AdmissionRequest.UID
+				return ret
+			}
+			if toleration.Key == "node-role.kubernetes.io/master" && toleration.Effect == corev1.TaintEffectNoSchedule {
+				ret = admissionctl.Denied("Not allowed to schedule a pod with NoSchedule taint on master node")
+				ret.UID = request.AdmissionRequest.UID
+				return ret
+			}
+			if toleration.Key == "node-role.kubernetes.io/master" && toleration.Effect == corev1.TaintEffectPreferNoSchedule {
+				ret = admissionctl.Denied("Not allowed to schedule a pod with PreferNoSchedule taint on master node")
+				ret.UID = request.AdmissionRequest.UID
+				return ret
+			}
+		}
+	}
+
+	// Hereafter, all requests are controlled by RBAC
+	ret = admissionctl.Allowed("Allowed to create Pod because of RBAC")
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// HandleRequest Decide if the incoming request is allowed
+func (s *PodWebhook) HandleRequest(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	request, _, err := utils.ParseHTTPRequest(r)
+	if err != nil {
+		log.Error(err, "Error parsing HTTP Request Body")
+		responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
+		return
+	}
+	// Is this a valid request?
+	if !s.Validate(request) {
+		responsehelper.SendResponse(w,
+			admissionctl.Errored(http.StatusBadRequest,
+				fmt.Errorf("Could not parse Namespace from request")))
+		return
+	}
+	// should the request be authorized?
+	responsehelper.SendResponse(w, s.authorized(request))
+}
+
+// NewWebhook creates a new webhook
+func NewWebhook() *PodWebhook {
+	scheme := runtime.NewScheme()
+	v1beta1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+
+	return &PodWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/pod/pod_test.go
+++ b/pkg/webhooks/pod/pod_test.go
@@ -1,0 +1,541 @@
+package pod
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	"k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func createRawPodJSON(name string, tolerations []corev1.Toleration, uid string, namespace string) (string, error) {
+	str := `{
+		"metadata": {
+			"name": "%s",
+			"namespace": "%s",
+			"uid": "%s"
+		},
+		"spec": {
+			"tolerations": %s
+		},
+		"users": null
+	}`
+
+	partial, err := json.Marshal(tolerations)
+	return fmt.Sprintf(str, name, namespace, uid, string(partial)), err
+}
+
+type podTestSuites struct {
+	testID          string
+	targetPod       string
+	namespace       string
+	username        string
+	operation       v1beta1.Operation
+	userGroups      []string
+	tolerations     []corev1.Toleration
+	shouldBeAllowed bool
+}
+
+func runPodTests(t *testing.T, tests []podTestSuites) {
+	gvk := metav1.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	}
+	gvr := metav1.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+
+	for _, test := range tests {
+		rawObjString, err := createRawPodJSON(test.targetPod, test.tolerations, test.testID, test.namespace)
+		if err != nil {
+			t.Fatalf("Couldn't create a JSON fragment %s", err.Error())
+		}
+
+		obj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		hook := NewWebhook()
+		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+
+		response, err := testutils.SendHTTPRequest(httprequest, hook)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+		if response.UID == "" {
+			t.Fatalf("No tracking UID associated with the response.")
+		}
+
+		if response.Allowed != test.shouldBeAllowed {
+			t.Fatalf("Mismatch: %s (groups=%s) %s %s the pod. Test's expectation is that the user %s", test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
+		}
+	}
+}
+
+func TestDedicatedAdminNegative(t *testing.T) {
+	tests := []podTestSuites{
+		{ //Dedicated admin can not deploy pod on master on infra nodes in openshift-operators, openshift-logging namespace or any other namespace that is not a core namespace like openshift-*, redhat-*, default, kube-*.
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-cant-deploy1",
+			namespace:  "random-project",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-cant-deploy2",
+			namespace:  "openshift-operators",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-cant-deploy3",
+			namespace:  "openshift-logging",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-cant-deploy4",
+			namespace:  "openshift-logging",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-cant-deploy5",
+			namespace:  "openshift-logging",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+	}
+	runPodTests(t, tests)
+}
+
+func TestDedicatedAdminPositive(t *testing.T) {
+	tests := []podTestSuites{
+		{ //Dedicated admin can deploy pod on master on infra if it is in a core namespace like openshift-*, redhat-*, default, kube-* with exceptions of openshift-operators and openshift-logging namespace.
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-can-deploy1",
+			namespace:  "openshift-apiserver",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-can-deploy2",
+			namespace:  "kube-system",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-can-deploy3",
+			namespace:  "redhat-config",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-can-deploy4",
+			namespace:  "default",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			operation:       v1beta1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "dedicated-admin-can-deploy5",
+			namespace:  "default",
+			username:   "dedicated-admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+	}
+	runPodTests(t, tests)
+}
+
+func TestUserNegative(t *testing.T) {
+	tests := []podTestSuites{
+		{ //User can not deploy pod on master on infra nodes in openshift-operators, openshift-logging namespace or any other namespace that is not a core namespace like openshift-*, redhat-*, default, kube-*.
+			targetPod:  "my-test-pod",
+			testID:     "user-alice-cant-deploy1",
+			namespace:  "openshift-logging",
+			username:   "alice",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-alice-cant-deploy2",
+			namespace:  "openshift-operators",
+			username:   "alice",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-alice-cant-deploy3",
+			namespace:  "my-little-project",
+			username:   "alice",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-alice-cant-deploy4",
+			namespace:  "default-configs",
+			username:   "Alice",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+	}
+	runPodTests(t, tests)
+
+}
+
+// Normal user won't be able to create pods in privileged namespaces as RBAC will disallow it.
+func TestUserPositive(t *testing.T) {
+	tests := []podTestSuites{
+		{ //User can deploy pod on master on infra if it is in a core namespace like openshift-*, redhat-*, default, kube-* with exceptions of openshift-operators and openshift-logging namespace.
+			targetPod:  "my-test-pod",
+			testID:     "user-bob-can-deploy1",
+			namespace:  "openshift-apiserver",
+			username:   "bob",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-bob-can-deploy2",
+			namespace:  "kube-system",
+			username:   "bob",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-bob-can-deploy3",
+			namespace:  "redhat-config",
+			username:   "bob",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-bob-can-deploy4",
+			namespace:  "default",
+			username:   "bob",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-bob-can-deploy4",
+			namespace:  "default",
+			username:   "bob",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			},
+			operation:       v1beta1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			targetPod:  "my-test-pod",
+			testID:     "user-bob-can-deploy4",
+			namespace:  "default",
+			username:   "bob",
+			userGroups: []string{"system:authenticated", "system:authenticated:oauth"},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "toleration key value2",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			operation:       v1beta1.Delete,
+			shouldBeAllowed: true,
+		},
+	}
+	runPodTests(t, tests)
+}


### PR DESCRIPTION
This commit adds in pod.go a webhook that will check the namespace in which the pods deploy, and if that namespace is openshift-logging, openshift-operators or a non-core namespace the deployment will not be allowed on master and infra nodes. This commit prevents the logging stack from targeting the infra nodes [OSD-4262](https://issues.redhat.com/browse/OSD-5269) and prevents customers from launching pods with workloads on master and infra JIRA ticket [OSD-4333](https://issues.redhat.com/browse/OSD-4333).
The unit tests for the pod webhook are in pod_test.go.