### PR TITLE
DRY out HTTP request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,39 @@ Ensure the git branch is current and run `make syncset`. The updated Template wi
 
 Each Webhook must register with, and therefor satisfy the interface specified in [pkg/webhooks/register.go](pkg/webhooks/register.go):
 
-
 ```go
+// imports shown here for clarity
+import (
+  admissionregv1 "k8s.io/api/admissionregistration/v1"
+  admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
 // Webhook interface
 type Webhook interface {
-	// HandleRequest handles an incoming webhook
-	HandleRequest(http.ResponseWriter, *http.Request)
-	// GetURI returns the URI for the webhook
-	GetURI() string
-	// Validate will validate the incoming request
-	Validate(admissionctl.Request) bool
-	// Name is the name of the webhook
-	Name() string
-	// FailurePolicy is how the hook config should react if k8s can't access it
-	FailurePolicy() admissionregv1.FailurePolicyType
-	// MatchPolicy mirrors validatingwebhookconfiguration.webhooks[].matchPolicy.
-	// If it is important to the webhook, be sure to check subResource vs
-	// requestSubResource.
-	MatchPolicy() *admissionregv1.MatchPolicyType
-	// Rules is a slice of rules on which this hook should trigger
-	Rules() []admissionregv1.RuleWithOperations
-	// SideEffects are what side effects, if any, this hook has. Refer to
-	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
-	SideEffects() *admissionregv1.SideEffectClass
-	//TimeoutSeconds returns an int32 representing how long to wait for this hook to complete
-	TimeoutSeconds() int32
+  // Authorized will determine if the request is allowed
+  Authorized(request admissionctl.Request) admissionctl.Response
+  // GetURI returns the URI for the webhook
+  GetURI() string
+  // Validate will validate the incoming request
+  Validate(admissionctl.Request) bool
+  // Name is the name of the webhook
+  Name() string
+  // FailurePolicy is how the hook config should react if k8s can't access it
+  FailurePolicy() admissionregv1.FailurePolicyType
+  // MatchPolicy mirrors validatingwebhookconfiguration.webhooks[].matchPolicy.
+  // If it is important to the webhook, be sure to check subResource vs
+  // requestSubResource.
+  MatchPolicy() *admissionregv1.MatchPolicyType
+  // Rules is a slice of rules on which this hook should trigger
+  Rules() []admissionregv1.RuleWithOperations
+  // SideEffects are what side effects, if any, this hook has. Refer to
+  // https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
+  SideEffects() *admissionregv1.SideEffectClass
+  //TimeoutSeconds returns an int32 representing how long to wait for this hook to complete
+  TimeoutSeconds() int32
 }
 ```
 
-The first four methods (`HandleRequest`, `GetURI`, `Validate` and `Name`) are involved with the process of handling the incoming JSON payload from the API server. `GetURI` and `Name` prepare the webserver to send to `HandleRequest` the payload and `Validate` ensures that the structure of the `AdmissionRequest` is appropriate, _not_ if the request should be permitted (this functionality is up to the webhook author to implement, and is not part of the interface).
+The first four methods (`Authorized`, `GetURI`, `Validate` and `Name`) are involved with the process of handling the incoming JSON payload from the API server. `GetURI` and `Name` prepare the webserver to send to determine if the request is `Authorized` and to `Validate` ensures that the structure of the `AdmissionRequest` is appropriate, _not_ if the request should be permitted (this functionality is up to the webhook author to implement, and is not part of the interface).
 
 The remaining methods (and also including `GetURI` and `Name`) are involved with [rendering YAML](#updating-selectorsyncset-template).
 
@@ -52,11 +56,11 @@ Registering involves creating a file in [pkg/webhooks](pkg/webhooks) (eg [add_na
 package webhooks
 
 import (
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/namespace"
+  "github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/namespace"
 )
 
 func init() {
-	Register(namespace.WebhookName, func() Webhook { return namespace.NewWebhook() })
+  Register(namespace.WebhookName, func() Webhook { return namespace.NewWebhook() })
 }
 ```
 
@@ -64,9 +68,13 @@ The signature is `Register(string, WebhookFactory)`, where a `WebhookFactory` is
 
 ### Helper Utils
 
-The [utils package](pkg/webhooks/utils/utils.go) exists to handle the most common activities a webhook would need to do: Parsing the incoming HTTP JSON request and a string slice content checker (`SliceContains(string, []string) bool`) since it's a common task to see if a group or username is a member of some safelisted list. Additional helper functions are described in [Sending Responses](#sending-responses).
+The [utils package](pkg/webhooks/utils/utils.go) provides a string slice content checker (`SliceContains(string, []string) bool`) since it's a common task to see if a group or username is a member of some safelisted list.
 
-It is strongly recommended to use the `ParseHTTPRequest` method. It handles various edge cases that could come up with the incoming HTTP request. Return signature for this function is `ParseHTTPRequest(r *http.Request) (admissionctl.Request, admissionctl.Response, error)`. Typically the `Request` is sufficient for processing; the `Response` is provided for completness sake and may go away in the future (See [Building a Response](#building-a-response)).
+## Is The Request Valid and Authorized
+
+The key difference between "valid" and "authorized" is that the former is asking if the incoming request is well-formed whereas the latter is asking if the user making the request is allowed to do so. Each webhook may have a different idea of what a "valid" request looks like, but some common feature may be if the request has a username set.
+
+`Validate` and `Authorized` serve as two entry points for the webserver: First it will ask if the request is valid and then it will ask if it is authorized. Thus, we can speak more about fulfulling the interface requirements for these two methods.
 
 ### Building a Response
 
@@ -78,23 +86,18 @@ To create a `Response` object (to reply to the incoming `AdmissionRequest`), one
 
 Use these functions once access has been determined, or in the event of some fundamental problem. A common use for `Errored` is when `Validate` fails. Refer to [Sending Responses](#sending-responses) for methods related to sending these `Response` objects back over the HTTP connection.
 
-### Sending Responses
-
-Once a [response is build](#building-a-response), it must be sent back to the HTTP client (typically from `HandleRequest` method). Using the [response helper](pkg/helpers/response.go) makes this quite easy with its `SendResponse(io.Writer, admissionctl.Response)` function.
-
-An example usage is:
+It is important to retain the UID from the incoming request with the outgoing response. A common pattern for this is:
 
 ```go
-	// Is this a valid request?
-	if !s.Validate(request) {
-		responsehelper.SendResponse(w,
-			admissionctl.Errored(http.StatusBadRequest,
-				fmt.Errorf("Could not parse Namespace from request")))
-		return
-	}
+  var ret admissionctl.Response
+  ret = admissionctl.Allowed("Request is allowed")
+  ret.UID = request.AdmissionRequest.UID
+  return ret
 ```
 
-This combines two features: [building a response](#building-a-response) (`Errored`) and sending it with the `SendResponse` function. In this case, it is perhaps because the incoming `Request` is not valid, perhaps because an expected `Namespace` couldn't be found within the request.
+### Sending Responses
+
+Once a [response is built](#building-a-response), it must be sent back to the HTTP client. This is done by returning the `admissionctl.Response` in the `Authorized` method. This structure can be [built up with the helpers mentioned above](#building-a-response).
 
 ### Writing Tests
 
@@ -105,10 +108,9 @@ Unit tests are important to ensure that webhooks behave as expected, and to help
 * `CreateHTTPRequest`
 * `SendHTTPRequest`
 
-
 The first function, `CanCanNot`, is very simple and designed to make test failure messages gramatically correct for. The three other functions are much more important to the testing process.
 
-The three helper functions are intended to provide for more integration style tests than true unit tests, as they assist in turning a specific set of test criteria a JSON representation and sending via `net/http/httptest` to the webhook's `HandleRequest`. When using `testutils.SendHTTPRequest`, the response is a `Response` object that can be used in the test suite to access the result of the webhook.
+The three helper functions are intended to provide for more integration style tests than true unit tests, as they assist in turning a specific set of test criteria a JSON representation and sending via `net/http/httptest` to the webhook's `Authorized`. When using `testutils.SendHTTPRequest`, the response is a `Response` object that can be used in the test suite to access the result of the webhook.
 
 ### End to End Testing
 
@@ -153,15 +155,15 @@ Then at the shell run:
 ```shell
 # make syncset
 docker run \
-		-v /Users/youruser/git/github.com/openshift/managed-cluster-validating-webhooks:/Users/youruser/git/github.com/openshift/managed-cluster-validating-webhooks \
-		-w /Users/youruser/git/github.com/openshift/managed-cluster-validating-webhooks \
-		--rm \
-		golang:1.14 \
-			go run \
-				build/syncset.go \
-				-exclude identity-validation,namespace-validation \
-				-outfile build/selectorsyncset.yaml \
-				-image "quay.io/app-sre/managed-cluster-validating-webhooks:\${IMAGE_TAG}"
+    -v /Users/youruser/git/github.com/openshift/managed-cluster-validating-webhooks:/Users/youruser/git/github.com/openshift/managed-cluster-validating-webhooks \
+    -w /Users/youruser/git/github.com/openshift/managed-cluster-validating-webhooks \
+    --rm \
+    golang:1.14 \
+      go run \
+        build/syncset.go \
+        -exclude identity-validation,namespace-validation \
+        -outfile build/selectorsyncset.yaml \
+        -image "quay.io/app-sre/managed-cluster-validating-webhooks:\${IMAGE_TAG}"
 # truncated ...
 ```
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/dispatcher"
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks"
 )
 
@@ -34,6 +35,7 @@ func main() {
 	if !*testHooks {
 		log.Info("HTTP server running at", "listen", net.JoinHostPort(*listenAddress, *listenPort))
 	}
+	dispatcher := dispatcher.NewDispatcher(webhooks.Webhooks)
 	seen := make(map[string]bool)
 	for name, hook := range webhooks.Webhooks {
 		realHook := hook()
@@ -44,7 +46,7 @@ func main() {
 		if !*testHooks {
 			log.Info("Listening", "webhookName", name, "URI", realHook.GetURI())
 		}
-		http.HandleFunc(realHook.GetURI(), realHook.HandleRequest)
+		http.HandleFunc(realHook.GetURI(), dispatcher.HandleRequest)
 	}
 	if *testHooks {
 		os.Exit(0)

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -1,0 +1,87 @@
+package dispatcher
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+)
+
+var log = logf.Log.WithName("dispatcher")
+
+// Dispatcher struct
+type Dispatcher struct {
+	hooks *map[string]webhooks.WebhookFactory // uri -> hookfactory
+	mu    sync.Mutex
+}
+
+// NewDispatcher new dispatcher
+func NewDispatcher(hooks webhooks.RegisteredWebhooks) *Dispatcher {
+	hookMap := make(map[string]webhooks.WebhookFactory)
+	for _, hook := range hooks {
+		hookMap[hook().GetURI()] = hook
+	}
+	return &Dispatcher{
+		hooks: &hookMap,
+	}
+}
+
+// HandleRequest http request
+// HTTP status code usage: When the request body is correctly parsed into a
+// request (utils.ParseHTTPRequest) then we should always send 200 OK and use
+// the response body (response.status.code) to indicate a problem. When instead
+// there's a problem with the HTTP request itself (404, an inability to parse a
+// request, or some internal problem) it is appropriate to use the HTTP status
+// code to communicate.
+func (d *Dispatcher) HandleRequest(w http.ResponseWriter, r *http.Request) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	log.Info("Handling request", "request", r.RequestURI)
+	url, err := url.Parse(r.RequestURI)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Error(err, "Couldn't parse request %s", r.RequestURI)
+		responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
+		return
+	}
+
+	// is it one of ours?
+	if hook, ok := (*d.hooks)[url.Path]; ok {
+		// it's one of ours, so let's attempt to parse the request
+		request, _, err := utils.ParseHTTPRequest(r)
+		// Problem even parsing an AdmissionReview, so use HTTP status code
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			log.Error(err, "Error parsing HTTP Request Body")
+			responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
+			return
+		}
+		// Valid AdmissionReview, but we can't do anything with it because we do not
+		// think the request inside is valid.
+		if !hook().Validate(request) {
+			responsehelper.SendResponse(w,
+				admissionctl.Errored(http.StatusBadRequest,
+					fmt.Errorf("Not a valid webhook request")))
+			return
+		}
+
+		// Dispatch
+		responsehelper.SendResponse(w, hook().Authorized(request))
+		return
+	}
+	log.Info("Request is not for a registered webhook.", "known_hooks", *d.hooks, "parsed_url", url, "lookup", (*d.hooks)[url.Path])
+	// Not a registered hook
+	// Note: This segment is not likely to be reached because there will not be
+	// any URI registered (handler set up) for an URI that would trigger this.
+	w.WriteHeader(404)
+	responsehelper.SendResponse(w,
+		admissionctl.Errored(http.StatusBadRequest,
+			fmt.Errorf("Request is not for a registered webhook")))
+}

--- a/pkg/webhooks/identity/identity.go
+++ b/pkg/webhooks/identity/identity.go
@@ -47,7 +47,7 @@ type identityRequest struct {
 	ProviderName string `json:"providerName"`
 }
 
-// IdentityWebhook validates a Identity change
+// IdentityWebhook validates an Identity change
 type IdentityWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme

--- a/pkg/webhooks/identity/identity.go
+++ b/pkg/webhooks/identity/identity.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sync"
 
-	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -48,7 +47,7 @@ type identityRequest struct {
 	ProviderName string `json:"providerName"`
 }
 
-// IdentityWebhook validates a Namespace change
+// IdentityWebhook validates a Identity change
 type IdentityWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme
@@ -132,26 +131,9 @@ func (s *IdentityWebhook) authorized(request admissionctl.Request) admissionctl.
 
 }
 
-// HandleRequest Decide if the incoming request is allowed
-func (s *IdentityWebhook) HandleRequest(w http.ResponseWriter, r *http.Request) {
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	request, _, err := utils.ParseHTTPRequest(r)
-	if err != nil {
-		log.Error(err, "Error parsing HTTP Request Body")
-		responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
-		return
-	}
-	// Is this a valid request?
-	if !s.Validate(request) {
-		responsehelper.SendResponse(w,
-			admissionctl.Errored(http.StatusBadRequest,
-				fmt.Errorf("Could not parse Namespace from request")))
-		return
-	}
-	// should the request be authorized?
-	responsehelper.SendResponse(w, s.authorized(request))
+// Authorized implements Webhook interface
+func (s *IdentityWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
 }
 
 // NewWebhook creates a new webhook

--- a/pkg/webhooks/register.go
+++ b/pkg/webhooks/register.go
@@ -1,19 +1,19 @@
 package webhooks
 
 import (
-	"net/http"
-
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+type RegisteredWebhooks map[string]WebhookFactory
+
 // Webhooks are all registered webhooks mapping name to hook
-var Webhooks = map[string]WebhookFactory{}
+var Webhooks = RegisteredWebhooks{}
 
 // Webhook interface
 type Webhook interface {
-	// HandleRequest handles an incoming webhook
-	HandleRequest(http.ResponseWriter, *http.Request)
+	// Authorized will determine if the request is allowed
+	Authorized(request admissionctl.Request) admissionctl.Response
 	// GetURI returns the URI for the webhook
 	GetURI() string
 	// Validate will validate the incoming request

--- a/pkg/webhooks/regularuser/regularuser.go
+++ b/pkg/webhooks/regularuser/regularuser.go
@@ -1,12 +1,9 @@
 package regularuser
 
 import (
-	"fmt"
-	"net/http"
 	"strings"
 	"sync"
 
-	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -77,7 +74,7 @@ var (
 	log = logf.Log.WithName(WebhookName)
 )
 
-// NamespaceWebhook validates a Namespace change
+// RegularuserWebhook protects various objects from unauthorized manipulation
 type RegularuserWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme
@@ -118,6 +115,11 @@ func (s *RegularuserWebhook) Validate(req admissionctl.Request) bool {
 	return valid
 }
 
+// Authorized implements Webhook interface
+func (s *RegularuserWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
 func (s *RegularuserWebhook) authorized(request admissionctl.Request) admissionctl.Response {
 	var ret admissionctl.Response
 
@@ -151,31 +153,6 @@ func (s *RegularuserWebhook) authorized(request admissionctl.Request) admissionc
 	ret = admissionctl.Denied("Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support")
 	ret.UID = request.AdmissionRequest.UID
 	return ret
-}
-
-// HandleRequest hndles the incoming HTTP request
-func (s *RegularuserWebhook) HandleRequest(w http.ResponseWriter, r *http.Request) {
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	request, _, err := utils.ParseHTTPRequest(r)
-	if err != nil {
-		log.Error(err, "Error parsing HTTP Request Body")
-		responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
-		return
-	}
-	// Is this a valid request?
-	if !s.Validate(request) {
-		resp := admissionctl.Errored(http.StatusBadRequest, fmt.Errorf("Could not parse Namespace from request"))
-		resp.UID = request.AdmissionRequest.UID
-		responsehelper.SendResponse(w, resp)
-
-		return
-	}
-	// should the request be authorized?
-
-	responsehelper.SendResponse(w, s.authorized(request))
-
 }
 
 // NewWebhook creates a new webhook

--- a/pkg/webhooks/subscription/subscription.go
+++ b/pkg/webhooks/subscription/subscription.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sync"
 
-	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -153,23 +152,9 @@ func (s *SubscriptionWebhook) authorized(request admissionctl.Request) admission
 	return ret
 }
 
-// HandleRequest hndles the incoming HTTP request
-func (s *SubscriptionWebhook) HandleRequest(w http.ResponseWriter, r *http.Request) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	request, _, err := utils.ParseHTTPRequest(r)
-	if err != nil {
-		log.Error(err, "Error parsing HTTP Request Body")
-		responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
-		return
-	}
-	// Is this a valid request?
-	if !s.Validate(request) {
-		responsehelper.SendResponse(w, admissionctl.Errored(http.StatusBadRequest, err))
-		return
-	}
-	// should the request be authorized?
-	responsehelper.SendResponse(w, s.authorized(request))
+// Authorized implements Webhook interface
+func (s *SubscriptionWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
 }
 
 // NewWebhook creates a new webhook


### PR DESCRIPTION
This commit will remove the `HandleRequest` requirement and formalize
the heretofore informal `authorized` methods into the Webhook interface
by introducing a new dispatcher package that is responsible for parsing
the HTTP payload into a Request object that webhookscan deal more
natively with. Each hook, with this change, will shed any knowledge of
the transport mechanism and only work with the higher level logic
specifically around webhooks.

Also updated are documentation and testutils package to support these
new changes.

Misc bug fixes:

* HTTP Status is correctly written copied from the response object
(unless it was omitted from the object somehow) * Fixed some copy/paste
errors

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>

fyi @cblecker @aliceh since if merged this will impact your work in #104 

/kind cleanup