### PR TITLE
Accommodate docker or podman in Makefile, to work around issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GOBUILDFLAGS = -gcflags="all=-trimpath=$(GOPATH)" -asmflags="all=-trimpath=$(GOP
 SELECTOR_SYNC_SET_HOOK_EXCLUDES ?= debug-hook
 SELECTOR_SYNC_SET_DESTINATION = build/selectorsyncset.yaml
 
-CONTAINER_ENGINE ?= docker
+CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 #eg, -v
 TESTOPTS ?=
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GOBUILDFLAGS = -gcflags="all=-trimpath=$(GOPATH)" -asmflags="all=-trimpath=$(GOP
 SELECTOR_SYNC_SET_HOOK_EXCLUDES ?= debug-hook
 SELECTOR_SYNC_SET_DESTINATION = build/selectorsyncset.yaml
 
-CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 #eg, -v
 TESTOPTS ?=
 


### PR DESCRIPTION
with docker in Fedora 31/32
docker on F31 gives: `cgroups: cgroup mountpoint does not exist: unknown`