### PR TITLE
OSD-5915 support new RHOAM groups

### DIFF
--- a/pkg/webhooks/group/group.go
+++ b/pkg/webhooks/group/group.go
@@ -37,7 +37,7 @@ type groupRequest struct {
 const (
 	WebhookName               string = "group-validation"
 	protectedAdminGroups      string = `(^dedicated-admins$|^cluster-admins$)`
-	protectedManagementGroups string = `(^osd-sre-admins$|^osd-sre-cluster-admins$|^osd-devaccess$|^layered-cs-sre-admins$)`
+	protectedManagementGroups string = `(^osd-sre-admins$|^osd-sre-cluster-admins$|^osd-devaccess$|^layered-cs-sre-admins$|^rhoam-cs-sre-admins$)`
 )
 
 var (

--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -17,17 +17,17 @@ import (
 )
 
 const (
-	WebhookName                  string = "namespace-validation"
-	privilegedNamespace          string = `(^kube.*|^openshift.*|^default$|^redhat.*)`
-	badNamespace                 string = `(^com$|^io$|^in$)`
-	privilegedServiceAccounts    string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*)`
-	layeredProductNamespace      string = `^redhat.*`
-	layeredProductAdminGroupName string = "layered-sre-cluster-admins"
+	WebhookName               string = "namespace-validation"
+	privilegedNamespace       string = `(^kube.*|^openshift.*|^default$|^redhat.*)`
+	badNamespace              string = `(^com$|^io$|^in$)`
+	privilegedServiceAccounts string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*)`
+	layeredProductNamespace   string = `^redhat.*`
 )
 
 var (
-	clusterAdminUsers = []string{"kube:admin", "system:admin"}
-	sreAdminGroups    = []string{"osd-sre-admins", "osd-sre-cluster-admins"}
+	clusterAdminUsers             = []string{"kube:admin", "system:admin"}
+	sreAdminGroups                = []string{"osd-sre-admins", "osd-sre-cluster-admins"}
+	layeredProductAdminGroupNames = []string{"layered-sre-cluster-admins", "rhoam-sre-cluster-admins"}
 
 	privilegedNamespaceRe       = regexp.MustCompile(privilegedNamespace)
 	badNamespaceRe              = regexp.MustCompile(badNamespace)
@@ -134,11 +134,13 @@ func (s *NamespaceWebhook) authorized(request admissionctl.Request) admissionctl
 	}
 	// L58-L62
 	// This must be prior to privileged namespace check
-	if utils.SliceContains(layeredProductAdminGroupName, request.UserInfo.Groups) &&
-		layeredProductNamespaceRe.Match([]byte(ns.GetName())) {
-		ret = admissionctl.Allowed("Layered product admins may access")
-		ret.UID = request.AdmissionRequest.UID
-		return ret
+	for _, userGroup := range request.UserInfo.Groups {
+		if utils.SliceContains(userGroup, layeredProductAdminGroupNames) &&
+			layeredProductNamespaceRe.Match([]byte(ns.GetName())) {
+			ret = admissionctl.Allowed("Layered product admins may access")
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
 	}
 	// L64-73
 	if privilegedNamespaceRe.Match([]byte(ns.GetName())) {

--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -297,6 +297,62 @@ func TestLayeredProducts(t *testing.T) {
 			operation:       v1beta1.Create,
 			shouldBeAllowed: false,
 		},
+		{
+			// RHOAM admins can manipulate in the rhoam ns, but not privileged ones
+			// note: ^redhat.* is a privileged ns, but rhoam admins have an exception in
+			// it (but not other privileged ns)
+			testID:          "rhoam-create-layered-ns",
+			targetNamespace: "redhat-layered-product",
+			username:        "test-user",
+			userGroups:      []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// RHOAM admins can't create a privileged ns
+			testID:          "rhoam-create-priv-ns",
+			targetNamespace: "openshift-test",
+			username:        "test-user",
+			userGroups:      []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// RHOAM admins can make an unprivileged ns
+			testID:          "rhoam-create-priv-ns",
+			targetNamespace: "my-ns",
+			username:        "test-user",
+			userGroups:      []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// RHOAM admins can not make an privileged ns
+			testID:          "rhoam-create-com-ns",
+			targetNamespace: "com",
+			username:        "test-user",
+			userGroups:      []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// RHOAM admins can not make an privileged ns
+			testID:          "rhoam-create-io-ns",
+			targetNamespace: "io",
+			username:        "test-user",
+			userGroups:      []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// RHOAM admins can not make an privileged ns
+			testID:          "rhoam-create-in-ns",
+			targetNamespace: "in",
+			username:        "test-user",
+			userGroups:      []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: false,
+		},
 	}
 	runNamespaceTests(t, tests)
 }

--- a/pkg/webhooks/subscription/subscription_test.go
+++ b/pkg/webhooks/subscription/subscription_test.go
@@ -531,6 +531,159 @@ func TestLayeredAdmins(t *testing.T) {
 	runSubscriptionTests(t, tests)
 }
 
+func TestRHOAMAdmins(t *testing.T) {
+	// these are basically the same tests as the dedicated-admin tests
+	// and those that shouldBeAllowed will fail due to RBAC (but not due
+	// to this webhook)
+	tests := []subscriptionTestSuites{
+		{
+			testID:           "rhoam-can-install-ES-logging-44",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "elasticsearch-operator",
+			channel:          "4.4",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-can-install-cluster-logging-44",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "cluster-logging",
+			channel:          "4.4",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-can-install-other-45",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "random-cool-operator",
+			channel:          "4.5",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-can-install-other",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "other-cool-operator",
+			channel:          "4.4",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-cannot-install-cluster-logging-45",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "cluster-logging",
+			channel:          "4.5",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-cannot-install-ES-logging-45",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "elasticsearch-operator",
+			channel:          "4.5",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-cannot-install-cluster-logging-46",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "cluster-logging",
+			channel:          "4.6",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-cannot-install-ES-logging-46",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Create,
+			subscriptionName: "elasticsearch-operator",
+			channel:          "4.6",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-can-upgrade-ES-logging-44",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "elasticsearch-operator",
+			channel:          "4.4",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-can-upgrade-cluster-logging-44",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "cluster-logging",
+			channel:          "4.4",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-can-upgrade-other-45",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "random-cool-operator",
+			channel:          "4.5",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-can-upgrade-other",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "other-cool-operator",
+			channel:          "43.2",
+			shouldBeAllowed:  true,
+		},
+		{
+			testID:           "rhoam-cannot-upgrade-cluster-logging-45",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "cluster-logging",
+			channel:          "4.5",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-cannot-upgrade-ES-logging-45",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "elasticsearch-operator",
+			channel:          "4.5",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-cannot-upgrade-cluster-logging-46",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "cluster-logging",
+			channel:          "4.6",
+			shouldBeAllowed:  false,
+		},
+		{
+			testID:           "rhoam-cannot-upgrade-ES-logging-46",
+			username:         "testuser@redhat.com",
+			userGroups:       []string{"rhoam-sre-cluster-admins", "system:authenticated", "system:authenticated:oauth"},
+			operation:        v1beta1.Update,
+			subscriptionName: "elasticsearch-operator",
+			channel:          "4.6",
+			shouldBeAllowed:  false,
+		},
+	}
+	runSubscriptionTests(t, tests)
+}
+
 func TestPrivilegedUsers(t *testing.T) {
 	tests := []subscriptionTestSuites{
 		{

--- a/pkg/webhooks/user/user.go
+++ b/pkg/webhooks/user/user.go
@@ -48,7 +48,7 @@ var (
 	// redhatGroups is a list of groups to which Red Hat associates must belong in
 	// order to have a User provisioned for them (typically by the
 	// openshift-authentication:oauth-openshift service account)
-	redhatGroups = []string{"osd-devaccess", "osd-sre-admins", "layered-cs-sre-admins"}
+	redhatGroups = []string{"osd-devaccess", "osd-sre-admins", "layered-cs-sre-admins", "rhoam-cs-sre-admins"}
 
 	// adminGroups restrict who is authorized to create a User for a Red Hat associate
 	adminGroups = []string{"osd-sre-admins", "osd-sre-cluster-admins", "system:serviceaccounts:openshift-authentication"}

--- a/pkg/webhooks/user/user_test.go
+++ b/pkg/webhooks/user/user_test.go
@@ -35,7 +35,7 @@ var testRedHatUsers = map[string][]string{
 	"osd-devaccess":         {"no-reply+devaccess1@redhat.com", "no-reply+devaccess2@redhat.com"},
 	"osd-sre-admins":        {"no-reply+osdsreadmin1@redhat.com", "no-reply+osdsreadmin2@redhat.com"},
 	"layered-cs-sre-admins": {"no-reply+lcssre+1@redhat.com", "no-reply@redhat.com", "should-use-otherIDP@redhat.com"},
-	"rhoam-cs-sre-admins": {"no-reply+rcssre+1@redhat.com", "no-reply+rcssre+2@redhat.com", "should-use-otherIDP@redhat.com"},
+	"rhoam-cs-sre-admins":   {"no-reply+rcssre+1@redhat.com", "no-reply+rcssre+2@redhat.com", "should-use-otherIDP@redhat.com"},
 }
 
 // testUserLoader implements Loader

--- a/pkg/webhooks/user/user_test.go
+++ b/pkg/webhooks/user/user_test.go
@@ -35,6 +35,7 @@ var testRedHatUsers = map[string][]string{
 	"osd-devaccess":         {"no-reply+devaccess1@redhat.com", "no-reply+devaccess2@redhat.com"},
 	"osd-sre-admins":        {"no-reply+osdsreadmin1@redhat.com", "no-reply+osdsreadmin2@redhat.com"},
 	"layered-cs-sre-admins": {"no-reply+lcssre+1@redhat.com", "no-reply@redhat.com", "should-use-otherIDP@redhat.com"},
+	"rhoam-cs-sre-admins": {"no-reply+rcssre+1@redhat.com", "no-reply+rcssre+2@redhat.com", "should-use-otherIDP@redhat.com"},
 }
 
 // testUserLoader implements Loader


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

New layered product groups `rhoam-cs-sre-admins` and `rhoam-sre-cluster-admins` have been introduced to manage the RHOAM layered product [0] [1].

For the introduction of these groups to be of any use to CS-SRE admins, the admission webhooks would need to be aware of them as well. This PR adds support for the new `rhoam-*` groups, largely treating them the same as the `layered-*` group.

A business justification for the need to separate the existing `layered-*` from the new `rhoam-*` has been requested to be added to [OSD-5915](https://issues.redhat.com/browse/OSD-5915). This PR is just getting some work in ahead of time.

### Which Jira/Github issue(s) this PR fixes?

[OSD-5915](https://issues.redhat.com/browse/OSD-5915) 

[0] https://github.com/openshift/managed-cluster-config/pull/562
[1] [CSSRE-1384](https://issues.redhat.com/browse/CSSRE-1384)