### PR TITLE
OSD-5697: Allow osde2e ServiceAccounts to create must-gather ns

### DIFF
--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -20,7 +20,7 @@ const (
 	WebhookName                  string = "namespace-validation"
 	privilegedNamespace          string = `(^kube.*|^openshift.*|^default$|^redhat.*)`
 	badNamespace                 string = `(^com$|^io$|^in$)`
-	privilegedServiceAccounts    string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*)`
+	privilegedServiceAccounts    string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*|osde2e-[a-z0-9]{5})`
 	layeredProductNamespace      string = `^redhat.*`
 	layeredProductAdminGroupName string = "layered-sre-cluster-admins"
 	docString                    string = `Managed OpenShift Customers may not modify privileged namespaces identified by this regular expression %s because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression %s because it could interfere with critical DNS resolution.`

--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -325,6 +325,15 @@ func TestServiceAccounts(t *testing.T) {
 			operation:       v1beta1.Delete,
 			shouldBeAllowed: true,
 		},
+		{
+			// osde2e-related things can create a ns for must-gather
+			testID:          "sa-create-ns-for-must-gather",
+			targetNamespace: "openshift-must-gather-qbjtf",
+			username:        "system:serviceaccount:osde2e-9a47q:cluster-admin", // This does *NOT* mean cluster-admin as in that ClusterRole
+			userGroups:      []string{"system:serviceaccounts:osde2e-9a47q", "system:authenticated", "system:authenticated:oauth"},
+			operation:       v1beta1.Create,
+			shouldBeAllowed: true,
+		},
 	}
 	runNamespaceTests(t, tests)
 }


### PR DESCRIPTION
At the end of an e2e run, the last step is to collect must-gather, which
requires the creation of a namespace for that purpose. This alters the
namespace hook to allow osde2e service accounts to create that
namespace.

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>