### PR TITLE
Add ObjectSelector support to Webhook interface

### DIFF
--- a/build/syncset.go
+++ b/build/syncset.go
@@ -354,6 +354,7 @@ func createValidatingWebhookConfiguration(hook webhooks.Webhook) admissionregv1.
 				SideEffects:             &sideEffects,
 				MatchPolicy:             &matchPolicy,
 				Name:                    fmt.Sprintf("%s.managed.openshift.io", hook.Name()),
+				ObjectSelector:          hook.ObjectSelector(),
 				FailurePolicy:           &failPolicy,
 				ClientConfig: admissionregv1.WebhookClientConfig{
 					Service: &admissionregv1.ServiceReference{

--- a/hack/documentation/document.go
+++ b/hack/documentation/document.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -20,6 +21,7 @@ var (
 type docuhook struct {
 	Name                string                              `json:"webhookName"`
 	Rules               []admissionregv1.RuleWithOperations `json:"rules,omitempty"`
+	ObjectSelector      *metav1.LabelSelector               `json:"webhookObjectSelector,omitempty"`
 	DocumentationString string                              `json:"documentString"`
 }
 
@@ -39,6 +41,7 @@ func WriteDocs() {
 		dochooks[i].DocumentationString = realHook.Doc()
 		if !*hideRules {
 			dochooks[i].Rules = realHook.Rules()
+			dochooks[i].ObjectSelector = realHook.ObjectSelector()
 		}
 	}
 

--- a/pkg/webhooks/group/group.go
+++ b/pkg/webhooks/group/group.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -62,6 +63,9 @@ var (
 		},
 	}
 )
+
+// ObjectSelector implements Webhook interface
+func (s *GroupWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
 
 func (s *GroupWebhook) Doc() string {
 	return fmt.Sprintf(docString, protectedManagementGroups, ocmUrl, protectedAdminGroups)

--- a/pkg/webhooks/identity/identity.go
+++ b/pkg/webhooks/identity/identity.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -53,6 +54,9 @@ type IdentityWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme
 }
+
+// ObjectSelector implements Webhook interface
+func (s *IdentityWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
 
 func (s *IdentityWebhook) Doc() string {
 	return fmt.Sprintf(docString, DefaultIdentityProvider)

--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -63,6 +64,9 @@ type NamespaceWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme
 }
+
+// ObjectSelector implements Webhook interface
+func (s *NamespaceWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
 
 func (s *NamespaceWebhook) Doc() string {
 	return fmt.Sprintf(docString, privilegedNamespace, badNamespace, protectedLabels)

--- a/pkg/webhooks/pod/pod.go
+++ b/pkg/webhooks/pod/pod.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -44,6 +45,9 @@ type PodWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme
 }
+
+// ObjectSelector implements Webhook interface
+func (s *PodWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
 
 func (s *PodWebhook) Doc() string {
 	return fmt.Sprintf(docString)

--- a/pkg/webhooks/register.go
+++ b/pkg/webhooks/register.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -28,6 +29,10 @@ type Webhook interface {
 	MatchPolicy() admissionregv1.MatchPolicyType
 	// Rules is a slice of rules on which this hook should trigger
 	Rules() []admissionregv1.RuleWithOperations
+	// ObjectSelector uses a *metav1.LabelSelector to augment the webhook's
+	// Rules() to match only on incoming requests which match the specific
+	// LabelSelector.
+	ObjectSelector() *metav1.LabelSelector
 	// SideEffects are what side effects, if any, this hook has. Refer to
 	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
 	SideEffects() admissionregv1.SideEffectClass

--- a/pkg/webhooks/regularuser/regularuser.go
+++ b/pkg/webhooks/regularuser/regularuser.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -103,6 +104,9 @@ func (s *RegularuserWebhook) Doc() string {
 	return fmt.Sprintf(docString, allGroups)
 }
 
+// ObjectSelector implements Webhook interface
+func (s *RegularuserWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
 // TimeoutSeconds implements Webhook interface
 func (s *RegularuserWebhook) TimeoutSeconds() int32 { return 2 }
 
@@ -145,6 +149,7 @@ func (s *RegularuserWebhook) Authorized(request admissionctl.Request) admissionc
 
 func (s *RegularuserWebhook) authorized(request admissionctl.Request) admissionctl.Response {
 	var ret admissionctl.Response
+	log.Info("Request Object", "request", request)
 
 	if request.AdmissionRequest.UserInfo.Username == "system:unauthenticated" {
 		// This could highlight a significant problem with RBAC since an

--- a/pkg/webhooks/subscription/subscription.go
+++ b/pkg/webhooks/subscription/subscription.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -58,6 +59,9 @@ type SubscriptionWebhook struct {
 	mu sync.Mutex
 	s  runtime.Scheme
 }
+
+// ObjectSelector implements Webhook interface
+func (s *SubscriptionWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
 
 func (s *SubscriptionWebhook) Doc() string {
 	return fmt.Sprintf(docString, esSubName, blockedChannels)

--- a/pkg/webhooks/user/user.go
+++ b/pkg/webhooks/user/user.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -90,6 +91,9 @@ type userRequest struct {
 		Name string `json:"name"`
 	} `json:"metadata"`
 }
+
+// ObjectSelector implements Webhook interface
+func (s *UserWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
 
 func (s *UserWebhook) Doc() string {
 	return fmt.Sprintf(docString, redHatIDP, redhatGroups, redHatIDP, redHatIDP)


### PR DESCRIPTION
In support of [OSD-3296](https://issues.redhat.com/browse/OSD-3296)

Starting in Kubernetes 1.15, webhooks gained the ability to use a
LabelSelector to "limit which requests are intercepted" based on the
labels of objects that would be sent. This PR adds to the Webhook
interface an `ObjectSelector() *metav1.LabelSelector` method which will
support this. It is recommended to set to `nil` if the particular
webhook has no such ObjectSelector restrictions (so that the resulting
selectorsyncset.yaml file does not include an empty map, for clarity
sake).

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>