### PR TITLE
Add Webhook removal note to delete the in-cluster objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,6 @@ pkg/webhooks/namespace
 ```
 
 Commit all changes and deploy as normal.
+
+Once the code changes are complete, remove the undesired `ValidatingWebhookConfiguration` object(s) manually from the cluster.
+


### PR DESCRIPTION
Removal of the in-cluster object(s) is not handled by the deletion of code in this project, so it will need to be cleaned out by hand afterwards.