### PR TITLE
Add backplane-cluster-admin

### DIFF
--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	clusterAdminUsers           = []string{"kube:admin", "system:admin"}
+	clusterAdminUsers           = []string{"kube:admin", "system:admin", "backplane-cluster-admin"}
 	sreAdminGroups              = []string{"osd-sre-admins", "osd-sre-cluster-admins"}
 	privilegedNamespaceRe       = regexp.MustCompile(privilegedNamespace)
 	badNamespaceRe              = regexp.MustCompile(badNamespace)


### PR DESCRIPTION
Jira; https://issues.redhat.com/browse/OSD-6373

backplane has added a new cluster-admin user for elevating privileges.

I encountered this today:
```
$ oc adm must-gather --as backplane-cluster-admin
[must-gather      ] OUT Using must-gather plugin-in image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b52c1d685b2ec2c674d8abb6ed0e69fd5e71f8c4e0c086fd6d2ca0e3f498470f
Error from server (Prevented from accessing Red Hat managed namespaces. Customer workloads should be placed in customer namespaces, and should not match this regular expression: (^kube.*|^openshift.*|^default$|^redhat.*)): admission webhook "namespace-validation.managed.openshift.io" denied the request: Prevented from accessing Red Hat managed namespaces. Customer workloads should be placed in customer namespaces, and should not match this regular expression: (^kube.*|^openshift.*|^default$|^redhat.*)
```
This PR should fix