### PR TITLE
Split out stderr for skopeo inspect

### DIFF
--- a/build/build_push.sh
+++ b/build/build_push.sh
@@ -15,29 +15,38 @@ usage() {
 # If the query fails for any reason, prints an error and *exits* nonzero.
 #
 # This function cribbed from:
-# https://github.com/openshift/boilerplate/blob/d2d6640ef28a7ce54ac639db32c825aa4bb492a0/boilerplate/_lib/common.sh#L77-L125
+# https://github.com/openshift/boilerplate/blob/0ba6566d544d0df9993a92b2286c131eb61f3e88/boilerplate/_lib/common.sh#L77-L135
 image_exists_in_repo() {
     local image_uri=$1
     local output
+    local rc
 
-    output=$(skopeo inspect docker://${image_uri} 2>&1)
-    if [[ $? -eq 0 ]]; then
+    local skopeo_stderr=$(mktemp)
+
+    output=$(skopeo inspect docker://${image_uri} 2>$skopeo_stderr)
+    rc=$?
+    # So we can delete the temp file right away...
+    stderr=$(cat $skopeo_stderr)
+    rm -f $skopeo_stderr
+    if [[ $rc -eq 0 ]]; then
         # The image exists. Sanity check the output.
         local digest=$(echo $output | jq -r .Digest)
         if [[ -z "$digest" ]]; then
             echo "Unexpected error: skopeo inspect succeeded, but output contained no .Digest"
             echo "Here's the output:"
             echo "$output"
+            echo "...and stderr:"
+            echo "$stderr"
             exit 1
         fi
         echo "Image ${image_uri} exists with digest $digest."
         return 0
-    elif [[ "$output" == *"manifest unknown"* ]]; then
+    elif [[ "$stderr" == *"manifest unknown"* ]]; then
         # We were able to talk to the repository, but the tag doesn't exist.
         # This is the normal "green field" case.
         echo "Image ${image_uri} does not exist in the repository."
         return 1
-    elif [[ "$output" == *"was deleted or has expired"* ]]; then
+    elif [[ "$stderr" == *"was deleted or has expired"* ]]; then
         # This should be rare, but accounts for cases where we had to
         # manually delete an image.
         echo "Image ${image_uri} was deleted from the repository."
@@ -53,7 +62,8 @@ image_exists_in_repo() {
         # In all these cases, we want to bail, because we don't know whether
         # the image exists (and we'd likely fail to push it anyway).
         echo "Error querying the repository for ${image_uri}:"
-        echo "$output"
+        echo "stdout: $output"
+        echo "stderr: $stderr"
         exit 1
     fi
 }


### PR DESCRIPTION
This started happening suddenly:

```
10:08:43 parse error: Invalid literal at line 1, column 6
10:08:43 Unexpected error: skopeo inspect succeeded, but output contained no .Digest
10:08:43 Here's the output:
10:08:43 time="2021-05-10T15:08:41Z" level=error msg="HEADER map[Content-Length:[185] Content-Type:[text/html] Date:[Mon, 10 May 2021 15:08:41 GMT] Server:[nginx/1.12.1]]"
10:08:43 {
10:08:43     "Name": "quay.io/app-sre/aws-account-operator",
10:08:43     "Digest": "sha256:02baefe6abe17a60f9751441fdd7223b3d79af5580639d4ea90285bbab28a0c7",
```

For some reason, `skopeo inspect` is now producing that header information on stderr, whereas it wasn't before.

Nevertheless, that's no excuse for glomming together stdout and stderr when we expect to be able to parse the former. So with this commit, we split stderr out and redirect it to a temporary file instead.