### PR TITLE
Authorize NetNamespace In Regular User Webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.out
 /coverage.txt
 /.vscode
+*.code-workspace

--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -399,6 +399,16 @@ objects:
           - subjectpermissions
           - subjectpermissions/*
           scope: '*'
+        - apiGroups:
+          - network.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - '*'
+          resources:
+          - netnamespaces
+          - netnamespaces/*
+          scope: '*'
         sideEffects: None
         timeoutSeconds: 2
     - apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
This adds authorization for [NetNamespace](https://docs.openshift.com/container-platform/4.5/rest_api/network_apis/netnamespace-network-openshift-io-v1.html).

This also fixes up some test utils to allow for additional parameters such as Name and Namespace.

https://github.com/openshift/managed-cluster-config/pull/839 depends on this being merged first, such that dedicated-admins cannot update protected namespaces.

https://issues.redhat.com/browse/OSD-7367