### PR TITLE
[OSD-7327] Apply owner label to resp.AuditAnnotations

### DIFF
--- a/pkg/helpers/response.go
+++ b/pkg/helpers/response.go
@@ -14,6 +14,13 @@ var log = logf.Log.WithName("response_helper")
 
 // SendResponse Send the AdmissionReview.
 func SendResponse(w io.Writer, resp admissionctl.Response) {
+
+	// Apply ownership annotation to allow for granular alerts for
+	// manipulation of SREP owned webhooks.
+	resp.AuditAnnotations = map[string]string{
+		"owner": "srep-managed-webhook",
+	}
+
 	encoder := json.NewEncoder(w)
 	responseAdmissionReview := admissionapi.AdmissionReview{
 		Response: &resp.AdmissionResponse,

--- a/pkg/helpers/response_test.go
+++ b/pkg/helpers/response_test.go
@@ -52,14 +52,14 @@ func TestResponse(t *testing.T) {
 			e:       nil,
 			status:  http.StatusOK,
 			// the writer sends a newline
-			expectedResult: formatOutput(`{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"test-uid","allowed":true}}`),
+			expectedResult: formatOutput(`{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"test-uid","allowed":true,"auditAnnotations":{"owner":"srep-managed-webhook"}}}`),
 		},
 		{
 			allowed:        false,
 			uid:            "test-fail-with-error",
 			e:              fmt.Errorf("request body is empty"),
 			status:         http.StatusBadRequest,
-			expectedResult: formatOutput(`{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request body is empty","code":400}}}`),
+			expectedResult: formatOutput(`{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request body is empty","code":400},"auditAnnotations":{"owner":"srep-managed-webhook"}}}`),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
[Ref OSD-7327](https://issues.redhat.com/browse/OSD-7327)

- In an attempt to narrow the scope of ValidatingWebhookConfigurations Splunk alerts, I'm adding an owner label which can be filtered on in Splunk alerts. This is being done to avoid raising alerts to SREP for customer owned ValidatingWebhookConfigurations