### PR TITLE
Update golang images to 1.16

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,11 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go mod vendor && make build
+RUN make build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
This PR updates the golang images for managed-cluster-validating-webhooks to go 1.16. Additionally, it modifies the Makefile to copy [this stanza](https://github.com/openshift/boilerplate/blob/328a6a5330ca758439829122dbdfafca9dcc79cf/boilerplate/test/test-base-convention/standard.mk#L31-L38) from boilerplate make everything compatible with the openshift/release image, and the Dockerfile is slightly modified to download and cache the modules in a layer in order to improve build speed during development.