### PR TITLE
OSD-7740 - Document all the components that are blocked by validating webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ A framework supporting validating webhooks for OpenShift.
 
 Ensure the git branch is current and run `make syncset`. The updated Template will be  [build/selectorsyncset.yaml](build/selectorsyncset.yaml) by default.
 
+## Updating documenation files
+
+Ensure the git branch is current and run `make docs > docs/webhooks.json && make DOCFLAGS=-hideRules docs > docs/webhooks-short.json`.
+
 ## Development
 
 Each Webhook must register with, and therefore satisfy the interface specified in [pkg/webhooks/register.go](pkg/webhooks/register.go):

--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -1,0 +1,22 @@
+[
+  {
+    "webhookName": "clusterlogging-validation",
+    "documentString": "Managed OpenShift Customers may set log retention outside the allowed range of 0-7 days"
+  },
+  {
+    "webhookName": "hiveownership-validation",
+    "documentString": "Managed OpenShift customers may not edit certain managed resources. A managed resource has a \"hive.openshift.io/managed\": \"true\" label."
+  },
+  {
+    "webhookName": "namespace-validation",
+    "documentString": "Managed OpenShift Customers may not modify privileged namespaces identified by this regular expression (^kube.*|^openshift.*|^default$|^redhat.*) because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression (^com$|^io$|^in$) because it could interfere with critical DNS resolution. Additionally, customers may not set or change the values of these Namespace labels [managed.openshift.io/storage-pv-quota-exempt managed.openshift.io/service-lb-quota-exempt]."
+  },
+  {
+    "webhookName": "pod-validation",
+    "documentString": "Managed OpenShift Customers may use tolerations on Pods that could cause those Pods to be scheduled on infra or master nodes."
+  },
+  {
+    "webhookName": "regular-user-validation",
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io cloudcredential.openshift.io machine.openshift.io admissionregistration.k8s.io cloudingress.managed.openshift.io upgrade.managed.openshift.io config.openshift.io operator.openshift.io network.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+  }
+]

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -1,0 +1,205 @@
+[
+  {
+    "webhookName": "clusterlogging-validation",
+    "rules": [
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE"
+        ],
+        "apiGroups": [
+          "logging.openshift.io"
+        ],
+        "apiVersions": [
+          "v1"
+        ],
+        "resources": [
+          "clusterloggings"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may set log retention outside the allowed range of 0-7 days"
+  },
+  {
+    "webhookName": "hiveownership-validation",
+    "rules": [
+      {
+        "operations": [
+          "UPDATE",
+          "DELETE"
+        ],
+        "apiGroups": [
+          "quota.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "clusterresourcequotas"
+        ],
+        "scope": "Cluster"
+      }
+    ],
+    "webhookObjectSelector": {
+      "matchLabels": {
+        "hive.openshift.io/managed": "true"
+      }
+    },
+    "documentString": "Managed OpenShift customers may not edit certain managed resources. A managed resource has a \"hive.openshift.io/managed\": \"true\" label."
+  },
+  {
+    "webhookName": "namespace-validation",
+    "rules": [
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE",
+          "DELETE"
+        ],
+        "apiGroups": [
+          ""
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "scope": "Cluster"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may not modify privileged namespaces identified by this regular expression (^kube.*|^openshift.*|^default$|^redhat.*) because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression (^com$|^io$|^in$) because it could interfere with critical DNS resolution. Additionally, customers may not set or change the values of these Namespace labels [managed.openshift.io/storage-pv-quota-exempt managed.openshift.io/service-lb-quota-exempt]."
+  },
+  {
+    "webhookName": "pod-validation",
+    "rules": [
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "v1"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "pods"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may use tolerations on Pods that could cause those Pods to be scheduled on infra or master nodes."
+  },
+  {
+    "webhookName": "regular-user-validation",
+    "rules": [
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "autoscaling.openshift.io",
+          "cloudcredential.openshift.io",
+          "machine.openshift.io",
+          "admissionregistration.k8s.io",
+          "cloudingress.managed.openshift.io",
+          "managed.openshift.io",
+          "splunkforwarder.managed.openshift.io",
+          "upgrade.managed.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "*/*"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "config.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "clusterversions",
+          "clusterversions/status",
+          "schedulers",
+          "apiservers"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "operator.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "kubeapiservers",
+          "openshiftapiservers"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          ""
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "nodes",
+          "nodes/*"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "managed.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "subjectpermissions",
+          "subjectpermissions/*"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "network.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "netnamespaces",
+          "netnamespaces/*"
+        ],
+        "scope": "*"
+      }
+    ],
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [autoscaling.openshift.io machine.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io config.openshift.io operator.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io cloudingress.managed.openshift.io managed.openshift.io network.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+  }
+]


### PR DESCRIPTION
Completes https://issues.redhat.com/browse/OSD-7740. 

Documentation for  managed-cluster-validating-webhooks can be generated using `make docs`; this PR captures the output so that the documentation is available without having to execute this command every time.