### PR TITLE
add validation webhook for scc

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -347,6 +347,37 @@ objects:
           scope: '*'
         sideEffects: None
         timeoutSeconds: 2
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        creationTimestamp: null
+        name: sre-scc-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /scc-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: scc-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - security.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - UPDATE
+          - DELETE
+          resources:
+          - securitycontextconstraints
+          scope: Cluster
+        sideEffects: None
+        timeoutSeconds: 2
   status: {}
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -18,5 +18,9 @@
   {
     "webhookName": "regular-user-validation",
     "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [autoscaling.openshift.io admissionregistration.k8s.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io operator.openshift.io network.openshift.io cloudcredential.openshift.io machine.openshift.io managed.openshift.io upgrade.managed.openshift.io config.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+  },
+  {
+    "webhookName": "scc-validation",
+    "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork node-exporter nonroot privileged restricted pipelines-scc]"
   }
 ]

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -201,5 +201,27 @@
       }
     ],
     "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [managed.openshift.io upgrade.managed.openshift.io operator.openshift.io network.openshift.io autoscaling.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io config.openshift.io machine.openshift.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+  },
+  {
+    "webhookName": "scc-validation",
+    "rules": [
+      {
+        "operations": [
+          "UPDATE",
+          "DELETE"
+        ],
+        "apiGroups": [
+          "security.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "securitycontextconstraints"
+        ],
+        "scope": "Cluster"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork node-exporter nonroot privileged restricted pipelines-scc]"
   }
 ]

--- a/pkg/webhooks/add_scc.go
+++ b/pkg/webhooks/add_scc.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/scc"
+)
+
+func init() {
+	Register(scc.WebhookName, func() Webhook { return scc.NewWebhook() })
+}

--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -36,7 +36,6 @@ var (
 		},
 	}
 	allowedUsers = []string{
-		"system:serviceaccount:openshift-monitoring:node-exporter",
 		"system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
 	}
 	allowedGroups = []string{}

--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -1,0 +1,207 @@
+package scc
+
+import (
+	"fmt"
+	"net/http"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName string = "scc-validation"
+	docString   string = `Managed OpenShift Customers may not modify the following default SCCs: %s`
+)
+
+var (
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+	scope         = admissionregv1.ClusterScope
+	rules         = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"UPDATE", "DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"security.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"securitycontextconstraints"},
+				Scope:       &scope,
+			},
+		},
+	}
+	allowedUsers = []string{
+		"system:serviceaccount:openshift-monitoring:node-exporter",
+		"system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
+	}
+	allowedGroups = []string{}
+	defaultSCCs   = []string{
+		"anyuid",
+		"hostaccess",
+		"hostmount-anyuid",
+		"hostnetwork",
+		"node-exporter",
+		"nonroot",
+		"privileged",
+		"restricted",
+		"pipelines-scc",
+	}
+)
+
+type SCCWebHook struct {
+	s runtime.Scheme
+}
+
+// NewWebhook creates the new webhook
+func NewWebhook() *SCCWebHook {
+	scheme := runtime.NewScheme()
+	admissionv1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+
+	return &SCCWebHook{
+		s: *scheme,
+	}
+}
+
+// Authorized implements Webhook interface
+func (s *SCCWebHook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+func (s *SCCWebHook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	scc, err := s.renderSCC(request)
+	if err != nil {
+		log.Error(err, "Couldn't render a SCC from the incoming request")
+		return admissionctl.Errored(http.StatusBadRequest, err)
+	}
+
+	if isDefaultSCC(scc) && !isAllowedUserGroup(request) {
+		switch request.Operation {
+		case admissionv1.Delete:
+			log.Info(fmt.Sprintf("Deleting operation detected on default SCC: %v", scc.Name))
+			ret = admissionctl.Denied(fmt.Sprintf("Deleting default SCCs %v is not allowed", defaultSCCs))
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		case admissionv1.Update:
+			log.Info(fmt.Sprintf("Updating operation detected on default SCC: %v", scc.Name))
+			ret = admissionctl.Denied(fmt.Sprintf("Modifying default SCCs %v is not allowed", defaultSCCs))
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
+	}
+
+	ret = admissionctl.Allowed("Request is allowed")
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// renderSCC render the SCC object from the requests
+func (s *SCCWebHook) renderSCC(request admissionctl.Request) (*securityv1.SecurityContextConstraints, error) {
+	decoder, err := admissionctl.NewDecoder(&s.s)
+	if err != nil {
+		return nil, err
+	}
+	scc := &securityv1.SecurityContextConstraints{}
+
+	if len(request.OldObject.Raw) > 0 {
+		err = decoder.DecodeRaw(request.OldObject, scc)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return scc, nil
+}
+
+// isAllowedUserGroup checks if the user or group is allowed to perform the action
+func isAllowedUserGroup(request admissionctl.Request) bool {
+	if utils.SliceContains(request.UserInfo.Username, allowedUsers) {
+		return true
+	}
+
+	for _, group := range allowedGroups {
+		if utils.SliceContains(group, request.UserInfo.Groups) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isDefaultSCC checks if the request is going to operate on the SCC in the
+// default list
+func isDefaultSCC(scc *securityv1.SecurityContextConstraints) bool {
+	for _, s := range defaultSCCs {
+		if scc.Name == s {
+			return true
+		}
+	}
+	return false
+}
+
+// GetURI implements Webhook interface
+func (s *SCCWebHook) GetURI() string {
+	return "/" + WebhookName
+}
+
+// Validate implements Webhook interface
+func (s *SCCWebHook) Validate(request admissionctl.Request) bool {
+	valid := true
+	valid = valid && (request.UserInfo.Username != "")
+	valid = valid && (request.Kind.Kind == "SecurityContextConstraints")
+
+	return valid
+}
+
+// Name implements Webhook interface
+func (s *SCCWebHook) Name() string {
+	return WebhookName
+}
+
+// FailurePolicy implements Webhook interface
+func (s *SCCWebHook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// MatchPolicy implements Webhook interface
+func (s *SCCWebHook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Rules implements Webhook interface
+func (s *SCCWebHook) Rules() []admissionregv1.RuleWithOperations {
+	return rules
+}
+
+// ObjectSelector implements Webhook interface
+func (s *SCCWebHook) ObjectSelector() *metav1.LabelSelector {
+	return nil
+}
+
+// SideEffects implements Webhook interface
+func (s *SCCWebHook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *SCCWebHook) TimeoutSeconds() int32 {
+	return timeout
+}
+
+// Doc implements Webhook interface
+func (s *SCCWebHook) Doc() string {
+	return fmt.Sprintf(docString, defaultSCCs)
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+// Return utils.DefaultLabelSelector() to stick with the default
+func (s *SCCWebHook) SyncSetLabelSelector() metav1.LabelSelector {
+	return utils.DefaultLabelSelector()
+}

--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -129,7 +129,7 @@ func TestUserPositive(t *testing.T) {
 		{
 			targetSCC:       "hostaccess",
 			testID:          "allowed-user-can-modify-default",
-			username:        "system:serviceaccount:openshift-monitoring:node-exporter",
+			username:        "system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
 			operation:       admissionv1.Update,
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
 			shouldBeAllowed: true,
@@ -145,7 +145,7 @@ func TestUserPositive(t *testing.T) {
 		{
 			targetSCC:       "hostaccess",
 			testID:          "allowed-user-can-delete-default",
-			username:        "system:serviceaccount:openshift-monitoring:node-exporter",
+			username:        "system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
 			operation:       admissionv1.Delete,
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
 			shouldBeAllowed: true,

--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -1,0 +1,155 @@
+package scc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type sccTestSuites struct {
+	testID          string
+	targetSCC       string
+	username        string
+	operation       admissionv1.Operation
+	userGroups      []string
+	shouldBeAllowed bool
+}
+
+const testObjectRaw string = `
+{
+	"apiVersion": "security.openshift.io/v1",
+	"kind": "SecurityContextConstraints",
+	"metadata": {
+		"name": "%s",
+		"uid": "1234"
+	}
+}`
+
+func createRawJSONString(name string) string {
+	s := fmt.Sprintf(testObjectRaw, name)
+	return s
+}
+
+func runSCCTests(t *testing.T, tests []sccTestSuites) {
+	gvk := metav1.GroupVersionKind{
+		Group:   "security.openshift.io",
+		Version: "v1",
+		Kind:    "SecurityContextConstraints",
+	}
+	gvr := metav1.GroupVersionResource{
+		Group:    "security.openshift.io",
+		Version:  "v1",
+		Resource: "securitycontextcontraints",
+	}
+
+	for _, test := range tests {
+		rawObjString := createRawJSONString(test.targetSCC)
+
+		obj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		oldObj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		hook := NewWebhook()
+		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, &oldObj)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+
+		response, err := testutils.SendHTTPRequest(httprequest, hook)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+		if response.UID == "" {
+			t.Fatalf("No tracking UID associated with the response.")
+		}
+
+		if response.Allowed != test.shouldBeAllowed {
+			t.Fatalf("Mismatch: %s (groups=%s) %s %s the scc. Test's expectation is that the user %s", test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
+		}
+	}
+}
+func TestUserNegative(t *testing.T) {
+	tests := []sccTestSuites{
+		{
+			targetSCC:       "hostnetwork",
+			testID:          "user-cant-delete-hostnetwork",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: false,
+		},
+		{
+			targetSCC:       "hostaccess",
+			testID:          "user-cant-delete-hostaccess",
+			username:        "user2",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: false,
+		},
+		{
+			targetSCC:       "anyuid",
+			testID:          "user-cant-delete-anyuid",
+			username:        "user3",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: false,
+		},
+		{
+			targetSCC:       "anyuid",
+			testID:          "user-cant-modify-hostnetwork",
+			username:        "user4",
+			operation:       admissionv1.Update,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: false,
+		},
+	}
+	runSCCTests(t, tests)
+}
+
+func TestUserPositive(t *testing.T) {
+	tests := []sccTestSuites{
+		{
+			targetSCC:       "testscc",
+			testID:          "user-can-modify-normal",
+			username:        "user1",
+			operation:       admissionv1.Update,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: true,
+		},
+		{
+			targetSCC:       "hostaccess",
+			testID:          "allowed-user-can-modify-default",
+			username:        "system:serviceaccount:openshift-monitoring:node-exporter",
+			operation:       admissionv1.Update,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: true,
+		},
+		{
+			targetSCC:       "testscc",
+			testID:          "user-can-delete-normal",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: true,
+		},
+		{
+			targetSCC:       "hostaccess",
+			testID:          "allowed-user-can-delete-default",
+			username:        "system:serviceaccount:openshift-monitoring:node-exporter",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: true,
+		},
+	}
+	runSCCTests(t, tests)
+}


### PR DESCRIPTION
add the webhook for scc with configurable allowed user and group

allow the service account for node-exporter by default

tested in live cluster that the webhook works well, and the upgrade can be finished without issue.

fixes: [OSD-9642](https://issues.redhat.com/browse/OSD-9642)

cc @NautiluX @Tessg22 @robotmaxtron 