### PR TITLE
Expand tests for service accounts [OSD-9355]

### DIFF
--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -360,6 +360,52 @@ func TestLayeredProducts(t *testing.T) {
 // TestServiceAccounts
 func TestServiceAccounts(t *testing.T) {
 	tests := []namespaceTestSuites{
+
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "openshift-ingress",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "default",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "kube-system",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "redhat-user",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "osde2e-xyz43",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
 		{
 			// serviceaccounts in privileged namespaces can interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
@@ -394,6 +440,42 @@ func TestServiceAccounts(t *testing.T) {
 			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
 			targetNamespace: privilegedNamespace,
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "kube-system",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "openshift-ingress",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "default",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "redhat-user",
 			username:        "system:serviceaccounts:unpriv-ns",
 			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,

--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -373,10 +373,46 @@ func TestServiceAccounts(t *testing.T) {
 		{
 			// serviceaccounts in privileged namespaces can interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
+			targetNamespace: "openshift-ingress",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "openshift-ingress",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
 			targetNamespace: "default",
 			username:        "system:serviceaccounts:openshift-test-ns",
 			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "default",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "default",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
 			shouldBeAllowed: true,
 		},
 		{
@@ -391,10 +427,46 @@ func TestServiceAccounts(t *testing.T) {
 		{
 			// serviceaccounts in privileged namespaces can interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
+			targetNamespace: "kube-system",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "kube-system",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
 			targetNamespace: "redhat-user",
 			username:        "system:serviceaccounts:openshift-test-ns",
 			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "redhat-user",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "redhat-user",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
 			shouldBeAllowed: true,
 		},
 		{
@@ -409,10 +481,46 @@ func TestServiceAccounts(t *testing.T) {
 		{
 			// serviceaccounts in privileged namespaces can interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
+			targetNamespace: "osde2e-xyz43",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "osde2e-xyz43",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
 			targetNamespace: privilegedNamespace,
 			username:        "system:serviceaccounts:openshift-test-ns",
 			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: privilegedNamespace,
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: privilegedNamespace,
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
 			shouldBeAllowed: true,
 		},
 		{
@@ -425,6 +533,18 @@ func TestServiceAccounts(t *testing.T) {
 			username:        "system:serviceaccounts:openshift-test-ns",
 			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
+			// serviceaccounts in privileged namespaces can interact with customer namespaces
+			// this is counterintuitive because they shouldn't. Recall that RBAC would
+			// deny any disallowed access, so the "true" here is deferring to
+			// Kubernetes RBAC
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "customer-ns",
+			username:        "system:serviceaccounts:openshift-test-ns",
+			userGroups:      []string{"system:serviceaccounts:openshift-test-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
 			shouldBeAllowed: true,
 		},
 		{
@@ -448,10 +568,46 @@ func TestServiceAccounts(t *testing.T) {
 		{
 			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
+			targetNamespace: privilegedNamespace,
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: privilegedNamespace,
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
 			targetNamespace: "kube-system",
 			username:        "system:serviceaccounts:unpriv-ns",
 			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "kube-system",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "kube-system",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
 			shouldBeAllowed: false,
 		},
 		{
@@ -466,7 +622,52 @@ func TestServiceAccounts(t *testing.T) {
 		{
 			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
 			testID:          "sa-create-priv-ns",
+			targetNamespace: "openshift-ingress",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "openshift-ingress",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
 			targetNamespace: "default",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "default",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "default",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "redhat-user",
 			username:        "system:serviceaccounts:unpriv-ns",
 			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
@@ -478,7 +679,16 @@ func TestServiceAccounts(t *testing.T) {
 			targetNamespace: "redhat-user",
 			username:        "system:serviceaccounts:unpriv-ns",
 			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
-			operation:       admissionv1.Create,
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			// serviceaccounts in unprivileged namespaces can not interact with privileged namespaces
+			testID:          "sa-create-priv-ns",
+			targetNamespace: "redhat-user",
+			username:        "system:serviceaccounts:unpriv-ns",
+			userGroups:      []string{"system:serviceaccounts:unpriv-ns", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
 			shouldBeAllowed: false,
 		},
 	}


### PR DESCRIPTION
Unit tests are expanded to cover the various scenarios around service accounts and privileged namespaces