### PR TITLE
remove pipelines-scc from the restricted list

### DIFF
--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -48,7 +48,6 @@ var (
 		"nonroot",
 		"privileged",
 		"restricted",
-		"pipelines-scc",
 	}
 )
 


### PR DESCRIPTION
pipelines-scc is managed by pipelines-operator, and it might be updated with the operator update