### PR TITLE
Only block clusterautoscalers and machineautoscalers resources

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -278,10 +278,10 @@ objects:
         name: regular-user-validation.managed.openshift.io
         rules:
         - apiGroups:
-          - autoscaling.openshift.io
           - cloudcredential.openshift.io
           - machine.openshift.io
           - admissionregistration.k8s.io
+          - addons.managed.openshift.io
           - cloudingress.managed.openshift.io
           - managed.openshift.io
           - ocmagent.managed.openshift.io
@@ -293,6 +293,16 @@ objects:
           - '*'
           resources:
           - '*/*'
+          scope: '*'
+        - apiGroups:
+          - autoscaling.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - '*'
+          resources:
+          - clusterautoscalers
+          - machineautoscalers
           scope: '*'
         - apiGroups:
           - config.openshift.io

--- a/pkg/webhooks/regularuser/regularuser.go
+++ b/pkg/webhooks/regularuser/regularuser.go
@@ -40,7 +40,6 @@ var (
 			Operations: []admissionregv1.OperationType{"*"},
 			Rule: admissionregv1.Rule{
 				APIGroups: []string{
-					"autoscaling.openshift.io",
 					"cloudcredential.openshift.io",
 					"machine.openshift.io",
 					"admissionregistration.k8s.io",
@@ -55,6 +54,15 @@ var (
 				},
 				APIVersions: []string{"*"},
 				Resources:   []string{"*/*"},
+				Scope:       &scope,
+			},
+		},
+		{
+			Operations: []admissionregv1.OperationType{"*"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"autoscaling.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"clusterautoscalers", "machineautoscalers"},
 				Scope:       &scope,
 			},
 		},

--- a/pkg/webhooks/regularuser/regularuser.go
+++ b/pkg/webhooks/regularuser/regularuser.go
@@ -44,9 +44,10 @@ var (
 					"cloudcredential.openshift.io",
 					"machine.openshift.io",
 					"admissionregistration.k8s.io",
-					"cloudingress.managed.openshift.io",
 					// Deny ability to manage SRE resources
 					// oc get --raw /apis | jq -r '.groups[] | select(.name | contains("managed")) | .name'
+					"addons.managed.openshift.io",
+					"cloudingress.managed.openshift.io",
 					"managed.openshift.io",
 					"ocmagent.managed.openshift.io",
 					"splunkforwarder.managed.openshift.io",


### PR DESCRIPTION
In the autoscaling.openshift.io apigroup, only restrict the clusterautoscalers and machineautoscalers resources.

Additionally, update the managed.openshift.io block using the provided command.

And lastly, fix some bugs in the tests

Fixes [OSD-10991](https://issues.redhat.com//browse/OSD-10991)