### PR TITLE
Update documentation files with document string fix for TechPreviewNo…

### DIFF
--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -17,7 +17,7 @@
   },
   {
     "webhookName": "regular-user-validation",
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [admissionregistration.k8s.io cloudingress.managed.openshift.io ocmagent.managed.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io config.openshift.io operator.openshift.io cloudcredential.openshift.io machine.openshift.io addons.managed.openshift.io managed.openshift.io autoscaling.openshift.io network.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [autoscaling.openshift.io config.openshift.io operator.openshift.io network.openshift.io machine.openshift.io admissionregistration.k8s.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io ocmagent.managed.openshift.io cloudcredential.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
   },
   {
     "webhookName": "scc-validation",
@@ -25,6 +25,6 @@
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",
-    "documentString": "Managed OpenShift Customers may use TechPreviewNoUpgrade FeatureGate that could prevent any future ability to do a y-stream upgrade to their clusters."
+    "documentString": "Managed OpenShift Customers may not use TechPreviewNoUpgrade FeatureGate that could prevent any future ability to do a y-stream upgrade to their clusters."
   }
 ]

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -217,7 +217,7 @@
         "scope": "*"
       }
     ],
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [admissionregistration.k8s.io cloudingress.managed.openshift.io ocmagent.managed.openshift.io operator.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io autoscaling.openshift.io config.openshift.io cloudcredential.openshift.io machine.openshift.io addons.managed.openshift.io managed.openshift.io network.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [network.openshift.io cloudcredential.openshift.io managed.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io config.openshift.io operator.openshift.io machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
   },
   {
     "webhookName": "scc-validation",
@@ -261,6 +261,6 @@
         "scope": "Cluster"
       }
     ],
-    "documentString": "Managed OpenShift Customers may use TechPreviewNoUpgrade FeatureGate that could prevent any future ability to do a y-stream upgrade to their clusters."
+    "documentString": "Managed OpenShift Customers may not use TechPreviewNoUpgrade FeatureGate that could prevent any future ability to do a y-stream upgrade to their clusters."
   }
 ]

--- a/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade.go
+++ b/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade.go
@@ -18,7 +18,7 @@ import (
 const (
 	WebhookName           string = "techpreviewnoupgrade-validation"
 	unprivilegedNamespace string = `(openshift-logging|openshift-operators)`
-	docString             string = `Managed OpenShift Customers may use TechPreviewNoUpgrade FeatureGate that could prevent any future ability to do a y-stream upgrade to their clusters.`
+	docString             string = `Managed OpenShift Customers may not use TechPreviewNoUpgrade FeatureGate that could prevent any future ability to do a y-stream upgrade to their clusters.`
 )
 
 var (


### PR DESCRIPTION
The TechPreviewNoUpgrade webhook document string was misleading. This PR corrects the issue.