### PR TITLE
ref: update the base image to a commonly used one

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,4 @@
-# https://github.com/openshift/ocp-build-data/blob/1a16e3dc96b8e4845d4b960628ccbe5edafe0510/streams.yml#L40
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.17-openshift-4.10 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir


### PR DESCRIPTION
I saw this while I was working on https://issues.redhat.com/browse/OSD-9791

Currently, the build fails on my local

```
make IMG_ORG=bseref build-base
/usr/bin/docker build -t quay.io/bseref/managed-cluster-validating-webhooks:f4474f7 -f /home/boran/go/src/github.com/managed-cluster-validating-webhooks/build/Dockerfile . && \
/usr/bin/docker tag quay.io/bseref/managed-cluster-validating-webhooks:f4474f7 quay.io/bseref/managed-cluster-validating-webhooks:latest
Sending build context to Docker daemon  1.404MB
Step 1/15 : FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
unauthorized: authentication required
make: *** [Makefile:82: build-image] Error 1
```

However, it works well and doesn't require auth if I update it to `registry.ci.openshift.org/openshift/release:golang-1.17` which is the one being used in CAD, hive, etc