### PR TITLE
Prevent deletion of new 4.11 SCCs

### DIFF
--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -45,10 +45,13 @@ var (
 		"hostaccess",
 		"hostmount-anyuid",
 		"hostnetwork",
+		"hostnetwork-v2",
 		"node-exporter",
 		"nonroot",
+		"nonroot-v2",
 		"privileged",
 		"restricted",
+		"restricted-v2",
 	}
 )
 

--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -112,6 +112,14 @@ func TestUserNegative(t *testing.T) {
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
 			shouldBeAllowed: false,
 		},
+		{
+			targetSCC:       "hostnetwork-v2",
+			testID:          "user-cant-delete-hostnetwork-v2",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: false,
+		},
 	}
 	runSCCTests(t, tests)
 }


### PR DESCRIPTION
OCP 4.11 introduces additional Pod Security SCCs which act as the SCC defaults on new 4.11+ clusters. [0]

MCVW already has protection against user deletion of default SCCs; this PR adds the new SCCs to the list of defaults.

Refs [OSD-13025](https://issues.redhat.com//browse/OSD-13025)

[0] https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission