### PR TITLE
empty commit to trigger build of images for remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,3 +344,4 @@ Commit all changes and deploy as normal.
 
 Once the code changes are complete, remove the undesired `ValidatingWebhookConfiguration` object(s) manually from the cluster.
 
+


### PR DESCRIPTION
Addresses [OSD-13325](https://issues.redhat.com/browse/OSD-13325), remediates CVE's found in the base image by rebuilding off the latest ubi-minimal. 