### PR TITLE
Add exception to promethuesrule webhook for  openshift-monitoring NS

### DIFF
--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -44,9 +44,6 @@ var (
 		},
 	}
 	log = logf.Log.WithName(WebhookName)
-
-	// TODO: [OSD-13909] Remove this exception for openshift-monitoring
-	acmAddonRuleLabels = map[string]string{"component": "ocm-policy-propagator", "app.kubernetes.io/name": "grc"}
 )
 
 // prometheusruleWebhook validates a prometheusRule change
@@ -85,13 +82,9 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 	if hookconfig.IsPrivilegedNamespace(pr.GetNamespace()) &&
 		// TODO: [OSD-13680] Remove this exception for openshift-customer-monitoring
 		pr.GetNamespace() != "openshift-customer-monitoring" &&
-		pr.GetNamespace() != "openshift-user-workload-monitoring" {
+		pr.GetNamespace() != "openshift-user-workload-monitoring" &&
 		// TODO: [OSD-13909] Remove this exception for openshift-monitoring
-		if pr.GetNamespace() == "openshift-monitoring" && isACMAddonRule(pr) {
-			ret = admissionctl.Allowed(fmt.Sprintf("Addons can operate on PrometheusRules in the 'openshift-monitoring' namespace"))
-			ret.UID = request.AdmissionRequest.UID
-			return ret
-		}
+		pr.GetNamespace() != "openshift-monitoring" {
 		log.Info(fmt.Sprintf("%s operation detected on managed namespace: %s", request.Operation, pr.GetNamespace()))
 		if isAllowedUser(request) {
 			ret = admissionctl.Allowed(fmt.Sprintf("User can do operations on PrometheusRules"))
@@ -115,18 +108,6 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 	ret = admissionctl.Allowed("Non managed namespace")
 	ret.UID = request.AdmissionRequest.UID
 	return ret
-}
-
-// isAddonRule checks if the PrometheusRule is used by an addon
-func isACMAddonRule(pr *prometheusRule) bool {
-	// ACM addon rule
-	for key, expected := range acmAddonRuleLabels {
-		value, ok := pr.Labels[key]
-		if !ok || value != expected {
-			return false
-		}
-	}
-	return true
 }
 
 // isclusterAdminUsers checks if the user or group is allowed to perform the action


### PR DESCRIPTION
Adds an exception to the prometheusrule webhook to allow requests from the openshift-monitoring namespace so that the ACM addon can install and upgrade on OSD & ROSA clusters.