### PR TITLE
OSD-14741 Fix image typo in hypershift selectorsyncset

### DIFF
--- a/hack/templates/00-managed-cluster-validating-webhooks-hs.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-managed-cluster-validating-webhooks-hs.SelectorSyncSet.yaml.tmpl
@@ -70,4 +70,4 @@ objects:
                           metadata:
                             name: validation-webhooks
                           spec:
-                            image: ${REGISTRY_IMG}:${IMAGE_DIGEST}
+                            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}


### PR DESCRIPTION
This corrects a small typo present in the Hypershift `managed-cluster-validating-webhooks` SelectorSyncSet that is preventing package-operator from installing the package.