### PR TITLE
OSD-15725 prevent SCC webhook blocking CVO updates

### DIFF
--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -38,6 +38,7 @@ var (
 	}
 	allowedUsers = []string{
 		"system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
+		"system:serviceaccount:openshift-cluster-version:default",
 	}
 	allowedGroups = []string{}
 	defaultSCCs   = []string{


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
MCVW's `sre-scc-validation` webhook has been observed to block z-stream upgrades between 4.13.0-ec.3 and 4.13.0-rc.0 due to the update of the `hostnetwork-v2` SCC as part of that upgrade.

This PR updates the list of allowed users that can perform updates on SCCs to include `cluster-version-operator`'s service account.

### Related ticket

[OSD-15725](https://issues.redhat.com//browse/OSD-15725)
