### PR TITLE
[Osd 15333 ] PKO to Inject caBundle of Management cluster to the Hosted cluster

### DIFF
--- a/config/package/manifest.yaml
+++ b/config/package/manifest.yaml
@@ -6,11 +6,20 @@ spec:
   scopes:
     - Namespaced
   phases:
+    - name: config
+    - name: rbac
+    - name: deploy
     - name: webhooks
       class: hosted-cluster
-    - name: rbac
-    - name: config
-    - name: deploy
+  config:
+    openAPIV3Schema:
+      properties:
+        serviceca:
+          description: Service Certificate Authority used for webhook client authentication
+          type: string
+      required:
+      - serviceca
+      type: object
   availabilityProbes:
     - probes:
         - condition:

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -149,6 +149,7 @@ webhooks:
   - v1
   clientConfig:
     url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/namespace-validation
+    caBundle: {{.config.serviceca | b64enc | toJson}}
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: namespace-validation.managed.openshift.io
@@ -180,6 +181,7 @@ webhooks:
   - v1
   clientConfig:
     url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/scc-validation
+    caBundle: {{.config.serviceca | b64enc | toJson}}
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: scc-validation.managed.openshift.io
@@ -210,6 +212,7 @@ webhooks:
   - v1
   clientConfig:
     url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/techpreviewnoupgrade-validation
+    caBundle: {{.config.serviceca | b64enc | toJson}}
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: techpreviewnoupgrade-validation.managed.openshift.io

--- a/hack/templates/00-managed-cluster-validating-webhooks-hs.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-managed-cluster-validating-webhooks-hs.SelectorSyncSet.yaml.tmpl
@@ -66,8 +66,22 @@ objects:
                       - complianceType: MustHave
                         objectDefinition:
                           apiVersion: package-operator.run/v1alpha1
-                          kind: Package
+                          kind: ObjectTemplate
                           metadata:
                             name: validation-webhooks
                           spec:
-                            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+                            template: |
+                              apiVersion: package-operator.run/v1alpha1
+                              kind: Package
+                              metadata:
+                                name: validation-webhooks
+                              spec:
+                                image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+                                config: {{toJson .config}}
+                            sources:
+                            - apiVersion: v1
+                              kind: ConfigMap
+                              name: openshift-service-ca.crt
+                              items:
+                              - key: .data['service-ca\.crt']
+                                destination: .serviceca


### PR DESCRIPTION
This PR is using new api of PKO to parameterizing Injection of caBundle of Management cluster to the Hosted cluster resource `ValidatingWebhookConfiguration`
Ref: https://package-operator.run/docs/concepts/object-template/

- Copy configmap `openshift-service-ca.crt`  value of `.data.service-ca\.crt` and inject into hosted cluster `ValidatingWebhookConfiguration`   `clientConfig.caBundle` which is deployed through PKO