### PR TITLE
Create new validating webhook for icp/icsp 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /coverage.txt
 /.vscode
 *.code-workspace
+.idea

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EXTRA_DEPS := $(find $(CURDIR)/build -type f -print) Makefile
 unexport GOFLAGS
 GOOS?=linux
 GOARCH?=amd64
-GOFLAGS_MOD?=
+GOFLAGS_MOD?=-mod=mod
 GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
 
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Managed Cluster Validating Webhooks
 
-A framework supporting validating webhooks for OpenShift.
+A framework supporting [validating admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) for OpenShift.
 
 - [Managed Cluster Validating Webhooks](#managed-cluster-validating-webhooks)
   - [Updating SelectorSyncSet Template](#updating-selectorsyncset-template)
@@ -45,36 +45,44 @@ Each Webhook must register with, and therefore satisfy the interface specified i
 // imports shown here for clarity
 import (
   admissionregv1 "k8s.io/api/admissionregistration/v1"
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
   admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
 // Webhook interface
 type Webhook interface {
-  // Authorized will determine if the request is allowed
-  Authorized(request admissionctl.Request) admissionctl.Response
-  // GetURI returns the URI for the webhook
-  GetURI() string
-  // Validate will validate the incoming request
-  Validate(admissionctl.Request) bool
-  // Name is the name of the webhook
-  Name() string
-  // FailurePolicy is how the hook config should react if k8s can't access it
-  FailurePolicy() admissionregv1.FailurePolicyType
-  // MatchPolicy mirrors validatingwebhookconfiguration.webhooks[].matchPolicy.
-  // If it is important to the webhook, be sure to check subResource vs
-  // requestSubResource.
-  MatchPolicy() *admissionregv1.MatchPolicyType
-  // Rules is a slice of rules on which this hook should trigger
-  Rules() []admissionregv1.RuleWithOperations
-  // SideEffects are what side effects, if any, this hook has. Refer to
-  // https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
-  SideEffects() *admissionregv1.SideEffectClass
-  //TimeoutSeconds returns an int32 representing how long to wait for this hook to complete
-  TimeoutSeconds() int32
-  // Doc returns a string for end-customer documentation purposes.
-  Doc() string
-  // SyncSetLabelSelector returns the label selector to use in the SyncSet.
-  // Return utils.DefaultLabelSelector() to stick with the default
-  SyncSetLabelSelector() metav1.LabelSelector
+	// Authorized will determine if the request is allowed
+	Authorized(request admissionctl.Request) admissionctl.Response
+	// GetURI returns the URI for the webhook
+	GetURI() string
+	// Validate will validate the incoming request
+	Validate(admissionctl.Request) bool
+	// Name is the name of the webhook
+	Name() string
+	// FailurePolicy is how the hook config should react if k8s can't access it
+	FailurePolicy() admissionregv1.FailurePolicyType
+	// MatchPolicy mirrors validatingwebhookconfiguration.webhooks[].matchPolicy.
+	// If it is important to the webhook, be sure to check subResource vs
+	// requestSubResource.
+	MatchPolicy() admissionregv1.MatchPolicyType
+	// Rules is a slice of rules on which this hook should trigger
+	Rules() []admissionregv1.RuleWithOperations
+	// ObjectSelector uses a *metav1.LabelSelector to augment the webhook's
+	// Rules() to match only on incoming requests which match the specific
+	// LabelSelector.
+	ObjectSelector() *metav1.LabelSelector
+	// SideEffects are what side effects, if any, this hook has. Refer to
+	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
+	SideEffects() admissionregv1.SideEffectClass
+	// TimeoutSeconds returns an int32 representing how long to wait for this hook to complete
+	TimeoutSeconds() int32
+	// Doc returns a string for end-customer documentation purposes.
+	Doc() string
+	// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+	// Return utils.DefaultLabelSelector() to stick with the default
+	SyncSetLabelSelector() metav1.LabelSelector
+	// HypershiftEnabled will return boolean value for hypershift enabled configurations
+	HypershiftEnabled() bool
 }
 ```
 

--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -202,6 +202,47 @@ objects:
         annotations:
           service.beta.openshift.io/inject-cabundle: "true"
         creationTimestamp: null
+        name: sre-imagecontentpolicies-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /imagecontentpolicies-validation
+        failurePolicy: Fail
+        matchPolicy: Equivalent
+        name: imagecontentpolicies-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - config.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - CREATE
+          - UPDATE
+          resources:
+          - imagecontentpolicies
+          scope: Cluster
+        - apiGroups:
+          - operator.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - CREATE
+          - UPDATE
+          resources:
+          - imagecontentsourcepolicies
+          scope: Cluster
+        sideEffects: None
+        timeoutSeconds: 2
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        creationTimestamp: null
         name: sre-namespace-validation
       webhooks:
       - admissionReviewVersions:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -61,7 +60,7 @@ func main() {
 		Addr: net.JoinHostPort(*listenAddress, *listenPort),
 	}
 	if *useTLS {
-		cafile, err := ioutil.ReadFile(*caCert)
+		cafile, err := os.ReadFile(*caCert)
 		if err != nil {
 			log.Error(err, "Couldn't read CA cert file")
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+	github.com/go-logr/logr v1.2.3
 	github.com/openshift/api v0.0.0-20230228142948-d170fcdc0fa6
 	github.com/openshift/cluster-logging-operator v0.0.0-20230328172346-05f4f8be54d5
 	github.com/openshift/hive/apis v0.0.0-20230327212335-7fd70848a6d5
@@ -20,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -36,18 +36,21 @@ func CanCanNot(b bool) string {
 // and finally the runtime.RawExtension representation of the request's Object or OldObject
 // The Object/OldObject is automatically inferred by the operation; delete operations will force OldObject
 // To create the RawExtension:
-// 	obj := runtime.RawExtension{
+//
+//	obj := runtime.RawExtension{
 //		Raw: []byte(rawObjString),
 //	}
+//
 // where rawObjString is a literal JSON blob, eg:
-// {
-//  "metadata": {
-//    "name": "namespace-name",
-//    "uid": "request-userid",
-//    "creationTimestamp": "2020-05-10T07:51:00Z"
-//  },
-//  "users": null
-// }
+//
+//	{
+//	 "metadata": {
+//	   "name": "namespace-name",
+//	   "uid": "request-userid",
+//	   "creationTimestamp": "2020-05-10T07:51:00Z"
+//	 },
+//	 "users": null
+//	}
 func CreateFakeRequestJSON(uid string,
 	gvk metav1.GroupVersionKind, gvr metav1.GroupVersionResource,
 	operation admissionv1.Operation,
@@ -56,10 +59,11 @@ func CreateFakeRequestJSON(uid string,
 
 	req := admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{
-			UID:       types.UID(uid),
-			Kind:      gvk,
-			Resource:  gvr,
-			Operation: operation,
+			UID:         types.UID(uid),
+			Kind:        gvk,
+			RequestKind: &gvk,
+			Resource:    gvr,
+			Operation:   operation,
 			UserInfo: authenticationv1.UserInfo{
 				Username: username,
 				Groups:   userGroups,

--- a/pkg/webhooks/add_imagecontentpolicies.go
+++ b/pkg/webhooks/add_imagecontentpolicies.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/imagecontentpolicies"
+)
+
+func init() {
+	Register(imagecontentpolicies.WebhookName, func() Webhook { return imagecontentpolicies.NewWebhook() })
+}

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
@@ -1,0 +1,194 @@
+package imagecontentpolicies
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName = "imagecontentpolicies-validation"
+	WebhookDoc  = "Managed OpenShift customers may not create ImageContentPolicy or ImageContentSourcePolicy resources that configure mirrors for quay.io, registry.redhat.com, nor registry.access.redhat.com."
+	// unauthorizedRepositoryMirrors is a regex that is used to reject certain specified repository mirrors.
+	// Generally all contained regexes follow a similar pattern, i.e. rejecting quay.io or quay.io/.*
+	unauthorizedRepositoryMirrors = `(^quay\.io(/.*)?$|^registry\.redhat\.io(/.*)?$|^registry\.access\.redhat\.com(/.*)?)`
+)
+
+type ImageContentPoliciesWebhook struct {
+	scheme *runtime.Scheme
+	log    logr.Logger
+}
+
+func NewWebhook() *ImageContentPoliciesWebhook {
+	return &ImageContentPoliciesWebhook{
+		scheme: runtime.NewScheme(),
+		log:    logf.Log.WithName(WebhookName),
+	}
+}
+
+func (w *ImageContentPoliciesWebhook) Authorized(request admission.Request) admission.Response {
+	decoder, err := admission.NewDecoder(w.scheme)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	icp := configv1.ImageContentPolicy{}
+	icsp := operatorv1alpha1.ImageContentSourcePolicy{}
+	allowedResp := admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			UID:     request.UID,
+			Allowed: true,
+		},
+	}
+
+	switch request.RequestKind.Kind {
+	case "ImageContentPolicy":
+		if err := decoder.Decode(request, &icp); err != nil {
+			w.log.Error(err, "failed to render an ImageContentPolicy from request")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if !authorizeImageContentPolicy(icp) {
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf(WebhookDoc))
+		}
+	case "ImageContentSourcePolicy":
+		if err := decoder.Decode(request, &icsp); err != nil {
+			w.log.Error(err, "failed to render an ImageContentSourcePolicy from request")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if !authorizeImageContentSourcePolicy(icsp) {
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf(WebhookDoc))
+		}
+	}
+
+	return allowedResp
+}
+
+func (w *ImageContentPoliciesWebhook) GetURI() string {
+	return "/" + WebhookName
+}
+
+func (w *ImageContentPoliciesWebhook) Validate(request admission.Request) bool {
+	if len(request.Object.Raw) > 0 {
+		// Unexpected, but if the request object is empty we have no hope of decoding it
+		return false
+	}
+
+	switch {
+	case request.Kind.Kind == "ImageContentPolicy":
+	case request.Kind.Kind == "ImageContentSourcePolicy":
+		return true
+	default:
+		return false
+	}
+
+	return false
+}
+
+func (w *ImageContentPoliciesWebhook) Name() string {
+	return WebhookName
+}
+
+func (w *ImageContentPoliciesWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	// Fail-closed because if we allow a problematic ImageContentPolicy/ImageContentSourcePolicy through,
+	// it will have significant impact on the cluster. We should not modify this to fail-open unless we have
+	// other specific observability and guidance to detect misconfigured ImageContentPolicy/ImageContentSourcePolicy
+	// resources.
+	return admissionregv1.Fail
+}
+
+func (w *ImageContentPoliciesWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	// Equivalent means a request should be intercepted if modifies a resource listed in rules, even via another API group or version.
+	// Specifying Equivalent is recommended, and ensures that webhooks continue to intercept the resources they expect when upgrades enable new versions of the resource in the API server.
+	return admissionregv1.Equivalent
+}
+
+func (w *ImageContentPoliciesWebhook) Rules() []admissionregv1.RuleWithOperations {
+	clusterScope := admissionregv1.ClusterScope
+	return []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{configv1.GroupName},
+				APIVersions: []string{"*"},
+				Resources:   []string{"imagecontentpolicies"},
+				Scope:       &clusterScope,
+			},
+		},
+		{
+			Operations: []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{operatorv1alpha1.GroupName},
+				APIVersions: []string{"*"},
+				Resources:   []string{"imagecontentsourcepolicies"},
+				Scope:       &clusterScope,
+			},
+		},
+	}
+}
+
+func (w *ImageContentPoliciesWebhook) ObjectSelector() *metav1.LabelSelector {
+	return nil
+}
+
+func (w *ImageContentPoliciesWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+func (w *ImageContentPoliciesWebhook) TimeoutSeconds() int32 {
+	return 2
+}
+
+func (w *ImageContentPoliciesWebhook) Doc() string {
+	return WebhookDoc
+}
+
+func (w *ImageContentPoliciesWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	return utils.DefaultLabelSelector()
+}
+
+func (w *ImageContentPoliciesWebhook) HypershiftEnabled() bool {
+	return true
+}
+
+// authorizeImageContentPolicy should reject an ImageContentPolicy that sets .spec.repositoryDigestMirrors to any of:
+// quay.io or quay.io/*
+// registry.redhat.io or registry.redhat.io/*
+// registry.access.redhat.com or registry.access.redhat.com/*
+func authorizeImageContentPolicy(icp configv1.ImageContentPolicy) bool {
+	unauthorizedRepositoryMirrorsRe := regexp.MustCompile(unauthorizedRepositoryMirrors)
+	for _, mirror := range icp.Spec.RepositoryDigestMirrors {
+		if unauthorizedRepositoryMirrorsRe.Match([]byte(mirror.Source)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// authorizeImageContentSourcePolicy should reject an ImageContentSourcePolicy that sets
+// .spec.repositoryDigestMirrors to any of:
+// quay.io or quay.io/*
+// registry.redhat.io or registry.redhat.io/*
+// registry.access.redhat.com or registry.access.redhat.com/*
+func authorizeImageContentSourcePolicy(icsp operatorv1alpha1.ImageContentSourcePolicy) bool {
+	unauthorizedRepositoryMirrorsRe := regexp.MustCompile(unauthorizedRepositoryMirrors)
+	for _, mirror := range icsp.Spec.RepositoryDigestMirrors {
+		if unauthorizedRepositoryMirrorsRe.Match([]byte(mirror.Source)) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
@@ -1,0 +1,344 @@
+package imagecontentpolicies
+
+import (
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test_authorizeImageContentPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		icp      configv1.ImageContentPolicy
+		expected bool
+	}{
+		{
+			name: "quay.io",
+			icp: configv1.ImageContentPolicy{
+				Spec: configv1.ImageContentPolicySpec{
+					RepositoryDigestMirrors: []configv1.RepositoryDigestMirrors{
+						{
+							Source: "quay.io",
+						},
+						{
+							Source: "quay.io/something",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "registry.redhat.io",
+			icp: configv1.ImageContentPolicy{
+				Spec: configv1.ImageContentPolicySpec{
+					RepositoryDigestMirrors: []configv1.RepositoryDigestMirrors{
+						{
+							Source: "registry.redhat.io/something",
+						},
+						{
+							Source: "registry.redhat.io",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "registry.access.redhat.com",
+			icp: configv1.ImageContentPolicy{
+				Spec: configv1.ImageContentPolicySpec{
+					RepositoryDigestMirrors: []configv1.RepositoryDigestMirrors{
+						{
+							Source: "registry.access.redhat.com",
+						},
+						{
+							Source: "registry.access.redhat.com/something",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "example.com",
+			icp: configv1.ImageContentPolicy{
+				Spec: configv1.ImageContentPolicySpec{
+					RepositoryDigestMirrors: []configv1.RepositoryDigestMirrors{
+						{
+							Source: "example.com",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := authorizeImageContentPolicy(test.icp); actual != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_authorizeImageContentSourcePolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		icsp     operatorv1alpha1.ImageContentSourcePolicy
+		expected bool
+	}{
+		{
+			name: "quay.io",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "quay.io",
+						},
+						{
+							Source: "quay.io/something",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "registry.redhat.io",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "registry.redhat.io/something",
+						},
+						{
+							Source: "registry.redhat.io",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "registry.access.redhat.com",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "registry.access.redhat.com",
+						},
+						{
+							Source: "registry.access.redhat.com/something",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "example.com",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "example.com",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := authorizeImageContentSourcePolicy(test.icsp); actual != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+const (
+	rawImageContentPolicy string = `{
+	"apiVersion": "config.openshift.io/v1",
+	"kind": "ImageContentPolicy",
+	"metadata": {
+        "name": "test"
+	},
+	"spec": {
+		"repositoryDigestMirrors": [
+			{
+				"source": "%s"
+			}
+		]
+	}
+}`
+	rawImageContentSourcePolicy string = `{
+	"apiVersion": "operator.openshift.io/v1alpha1",
+	"kind": "ImageContentSourcePolicy",
+	"metadata": {
+        "name": "test"
+	},
+	"spec": {
+		"repositoryDigestMirrors": [
+			{
+				"source": "%s"
+			}
+		]
+	}
+}`
+)
+
+func TestImageContentPolicy(t *testing.T) {
+	icpgvk := metav1.GroupVersionKind{
+		Group:   configv1.GroupName,
+		Version: configv1.GroupVersion.Version,
+		Kind:    "ImageContentPolicy",
+	}
+	icpgvr := metav1.GroupVersionResource{
+		Group:    configv1.GroupName,
+		Version:  configv1.GroupVersion.Version,
+		Resource: "imagecontentpolicies",
+	}
+	icspgvk := metav1.GroupVersionKind{
+		Group:   operatorv1alpha1.GroupName,
+		Version: operatorv1alpha1.GroupVersion.Version,
+		Kind:    "ImageContentSourcePolicy",
+	}
+	icspgvr := metav1.GroupVersionResource{
+		Group:    operatorv1alpha1.GroupName,
+		Version:  operatorv1alpha1.GroupVersion.Version,
+		Resource: "imagecontentsourcepolicies",
+	}
+	tests := []struct {
+		name    string
+		op      admissionv1.Operation
+		gvk     metav1.GroupVersionKind
+		gvr     metav1.GroupVersionResource
+		obj     *runtime.RawExtension
+		oldObj  *runtime.RawExtension
+		allowed bool
+	}{
+		{
+			name: "allowed-creation-icp",
+			op:   admissionv1.Create,
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "example.com")),
+			},
+			gvk:     icpgvk,
+			gvr:     icpgvr,
+			allowed: true,
+		},
+		{
+			name: "authorized-update-icp",
+			op:   admissionv1.Create,
+			oldObj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "registry.access.redhat.com")),
+			},
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "example.com")),
+			},
+			gvk:     icpgvk,
+			gvr:     icpgvr,
+			allowed: true,
+		},
+		{
+			name: "unauthorized-creation-icp",
+			op:   admissionv1.Create,
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "quay.io")),
+			},
+			gvk:     icpgvk,
+			gvr:     icpgvr,
+			allowed: false,
+		},
+		{
+			name: "unauthorized-update-icp",
+			op:   admissionv1.Create,
+			oldObj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "example.com")),
+			},
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "registry.redhat.io/test")),
+			},
+			gvk:     icpgvk,
+			gvr:     icpgvr,
+			allowed: false,
+		},
+		{
+			name: "allowed-creation-icsp",
+			op:   admissionv1.Create,
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "example.com")),
+			},
+			gvk:     icspgvk,
+			gvr:     icspgvr,
+			allowed: true,
+		},
+		{
+			name: "authorized-update-icp",
+			op:   admissionv1.Create,
+			oldObj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "registry.access.redhat.com")),
+			},
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "example.com")),
+			},
+			gvk:     icspgvk,
+			gvr:     icspgvr,
+			allowed: true,
+		},
+		{
+			name: "unauthorized-creation-icp",
+			op:   admissionv1.Create,
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "quay.io")),
+			},
+			gvk:     icspgvk,
+			gvr:     icspgvr,
+			allowed: false,
+		},
+		{
+			name: "unauthorized-update-icp",
+			op:   admissionv1.Create,
+			oldObj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "example.com")),
+			},
+			obj: &runtime.RawExtension{
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "registry.redhat.io/test")),
+			},
+			gvk:     icspgvk,
+			gvr:     icspgvr,
+			allowed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hook := NewWebhook()
+			req, err := testutils.CreateHTTPRequest(hook.GetURI(), test.name, test.gvk, test.gvr, test.op, "", []string{}, test.obj, test.oldObj)
+			if err != nil {
+				t.Errorf("failed to create test HTTP request: %v", err)
+			}
+
+			resp, err := testutils.SendHTTPRequest(req, hook)
+			if err != nil {
+				t.Errorf("failed to send test HTTP request: %v", err)
+			}
+
+			if resp.Allowed != test.allowed {
+				t.Errorf("expected allowed: %v, got allowed: %v", test.allowed, resp.Allowed)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/register.go
+++ b/pkg/webhooks/register.go
@@ -22,10 +22,12 @@ type Webhook interface {
 	// Name is the name of the webhook
 	Name() string
 	// FailurePolicy is how the hook config should react if k8s can't access it
+	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
 	FailurePolicy() admissionregv1.FailurePolicyType
 	// MatchPolicy mirrors validatingwebhookconfiguration.webhooks[].matchPolicy.
 	// If it is important to the webhook, be sure to check subResource vs
 	// requestSubResource.
+	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy
 	MatchPolicy() admissionregv1.MatchPolicyType
 	// Rules is a slice of rules on which this hook should trigger
 	Rules() []admissionregv1.RuleWithOperations
@@ -37,13 +39,15 @@ type Webhook interface {
 	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
 	SideEffects() admissionregv1.SideEffectClass
 	// TimeoutSeconds returns an int32 representing how long to wait for this hook to complete
+	// The timeout value must be between 1 and 30 seconds.
+	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
 	TimeoutSeconds() int32
 	// Doc returns a string for end-customer documentation purposes.
 	Doc() string
 	// SyncSetLabelSelector returns the label selector to use in the SyncSet.
 	// Return utils.DefaultLabelSelector() to stick with the default
 	SyncSetLabelSelector() metav1.LabelSelector
-	//HypershiftEnabled will return boolean value for hypershift enabled configurations
+	// HypershiftEnabled will return boolean value for hypershift enabled configurations
 	HypershiftEnabled() bool
 }
 

--- a/pkg/webhooks/utils/utils.go
+++ b/pkg/webhooks/utils/utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 
@@ -55,7 +55,7 @@ func ParseHTTPRequest(r *http.Request) (admissionctl.Request, admissionctl.Respo
 	var err error
 	var body []byte
 	if r.Body != nil {
-		if body, err = ioutil.ReadAll(r.Body); err != nil {
+		if body, err = io.ReadAll(r.Body); err != nil {
 			resp = admissionctl.Errored(http.StatusBadRequest, err)
 			return req, resp, err
 		}


### PR DESCRIPTION
[ImageContentPolicy](https://docs.openshift.com/container-platform/4.12/rest_api/config_apis/imagecontentpolicy-config-openshift-io-v1.html) and [ImageContentSourcePolicy](https://docs.openshift.com/container-platform/4.12/rest_api/operator_apis/imagecontentsourcepolicy-operator-openshift-io-v1alpha1.html) resources allow
customers to configure repository mirrors. This validating webhook will
prevent configuring mirrors for quay.io, registry.redhat.io, and
registry.access.redhat.com repositories as those will likely have an
adverse affect on managed OpenShift.

[OSD-15757](https://issues.redhat.com//browse/OSD-15757)