### PR TITLE
Prevent ACM from acting on PKO templates

### DIFF
--- a/hack/templates/00-managed-cluster-validating-webhooks-hs.SelectorSyncSet.yaml.tmpl
+++ b/hack/templates/00-managed-cluster-validating-webhooks-hs.SelectorSyncSet.yaml.tmpl
@@ -57,6 +57,8 @@ objects:
                   kind: ConfigurationPolicy
                   metadata:
                     name: managed-cluster-validating-webhooks
+                    annotations:
+                      policy.open-cluster-management.io/disable-templates: "true"
                   spec:
                     namespaceSelector:
                       matchLabels:


### PR DESCRIPTION
The `{{ toJson ... }}` package-operator template currently being used in the MCVW `ObjectTemplate` resource is mistakenly being treated by ACM as an ACM policy template, causing the policy to not be applied.

This corrects that by adding an annotation which will prevent ACM from applying any templates to the resource. (which is fine, as there are no ACM templates being used in it)

Refs [OSD-15333](https://issues.redhat.com//browse/OSD-15333)