### PR TITLE
Continue blocking registry.redhat.io exactly, but allow mirroring otherwise

### DIFF
--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
@@ -18,10 +18,11 @@ import (
 
 const (
 	WebhookName = "imagecontentpolicies-validation"
-	WebhookDoc  = "Managed OpenShift customers may not create ImageContentPolicy or ImageContentSourcePolicy resources that configure mirrors for quay.io, registry.redhat.com, nor registry.access.redhat.com."
+	WebhookDoc  = "Managed OpenShift customers may not create ImageContentPolicy or ImageContentSourcePolicy resources that configure mirrors for quay.io, registry.redhat.io, nor registry.access.redhat.com."
 	// unauthorizedRepositoryMirrors is a regex that is used to reject certain specified repository mirrors.
-	// Generally all contained regexes follow a similar pattern, i.e. rejecting quay.io or quay.io/.*
-	unauthorizedRepositoryMirrors = `(^quay\.io(/.*)?$|^registry\.redhat\.io(/.*)?$|^registry\.access\.redhat\.com(/.*)?)`
+	// Only registry.redhat.io exactly is blocked, while all other contained regexes
+	// follow a similar pattern, i.e. rejecting quay.io or quay.io/.*
+	unauthorizedRepositoryMirrors = `(^registry\.redhat\.io$|^quay\.io(/.*)?$|^registry\.access\.redhat\.com(/.*)?)`
 )
 
 type ImageContentPoliciesWebhook struct {

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
@@ -41,9 +41,6 @@ func Test_authorizeImageContentPolicy(t *testing.T) {
 				Spec: configv1.ImageContentPolicySpec{
 					RepositoryDigestMirrors: []configv1.RepositoryDigestMirrors{
 						{
-							Source: "registry.redhat.io/something",
-						},
-						{
 							Source: "registry.redhat.io",
 						},
 					},
@@ -72,6 +69,9 @@ func Test_authorizeImageContentPolicy(t *testing.T) {
 			icp: configv1.ImageContentPolicy{
 				Spec: configv1.ImageContentPolicySpec{
 					RepositoryDigestMirrors: []configv1.RepositoryDigestMirrors{
+						{
+							Source: "registry.redhat.io/something",
+						},
 						{
 							Source: "example.com",
 						},
@@ -270,7 +270,7 @@ func TestImageContentPolicy(t *testing.T) {
 				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "example.com")),
 			},
 			obj: &runtime.RawExtension{
-				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "registry.redhat.io/test")),
+				Raw: []byte(fmt.Sprintf(rawImageContentPolicy, "registry.redhat.io")),
 			},
 			gvk:     icpgvk,
 			gvr:     icpgvr,
@@ -316,7 +316,7 @@ func TestImageContentPolicy(t *testing.T) {
 				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "example.com")),
 			},
 			obj: &runtime.RawExtension{
-				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "registry.redhat.io/test")),
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "registry.redhat.io")),
 			},
 			gvk:     icspgvk,
 			gvr:     icspgvr,


### PR DESCRIPTION
Due to recent findings in OSD-15757, teams are mirroring specific repos under registry.redhat.io