### PR TITLE
Unit test icp webhook validation and authorization

### DIFF
--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
@@ -11,7 +11,6 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -31,11 +30,8 @@ type ImageContentPoliciesWebhook struct {
 }
 
 func NewWebhook() *ImageContentPoliciesWebhook {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(configv1.Install(scheme))
-	utilruntime.Must(operatorv1alpha1.Install(scheme))
 	return &ImageContentPoliciesWebhook{
-		scheme: scheme,
+		scheme: runtime.NewScheme(),
 		log:    logf.Log.WithName(WebhookName),
 	}
 }


### PR DESCRIPTION
This PR adds unit tests that would have caught the bugs that were fixed in #215 and #216

Of note is that GVK's need not be registered with the scheme because it marshals the object into `unstructured.Unstructured` under the hood and it passes the unit test!

[OSD-15757](https://issues.redhat.com//browse/OSD-15757)