### PR TITLE
OSD-16717 remove validation-webhook service account

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -29,38 +29,6 @@ objects:
       spec: {}
       status: {}
     - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        creationTimestamp: null
-        name: validation-webhook
-        namespace: openshift-validation-webhook
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        creationTimestamp: null
-        name: webhook-validation-cr
-      rules:
-      - apiGroups:
-        - user.openshift.io
-        resources:
-        - groups
-        verbs:
-        - list
-        - get
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        creationTimestamp: null
-        name: webhook-validation
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: webhook-validation-cr
-      subjects:
-      - kind: ServiceAccount
-        name: validation-webhook
-        namespace: openshift-validation-webhook
-    - apiVersion: v1
       kind: ConfigMap
       metadata:
         annotations:
@@ -140,7 +108,6 @@ objects:
                 name: service-ca
                 readOnly: true
             restartPolicy: Always
-            serviceAccountName: validation-webhook
             tolerations:
             - effect: NoSchedule
               key: node-role.kubernetes.io/master

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -1,13 +1,5 @@
 ---
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    package-operator.run/phase: rbac
-  creationTimestamp: null
-  name: validation-webhook
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
@@ -117,7 +109,6 @@ spec:
           name: service-ca
           readOnly: true
       restartPolicy: Always
-      serviceAccountName: validation-webhook
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/hosted-control-plane
@@ -162,7 +153,8 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - imagecontentpolicies
+    - imagedigestmirrorsets
+    - imagetagmirrorsets
     scope: Cluster
   - apiGroups:
     - operator.openshift.io


### PR DESCRIPTION
# What is this PR?
Removes the:
- `validation-webhook` ServiceAccount
- `webhook-validation-cr` ClusterRole
- `webhook-validation` ClusterRoleBinding
- the use of the `validation-webhook` in the OSD/ROSA DaemonSet and HCP Deployment

# Why?
Before SRE had backplane we had to check group membership within a webhook.  The RBAC for this was bound at a ClusterRoleBinding.  It is still in place today.  For HCP the SA bound to the webhook pods still exists and projects the SA token but in this context (HCP) there is no RBAC assigned.

There is no reason for SRE webhooks to have KAS access anymore and it should be removed.

# Refs
OSD-16717
