### PR TITLE
OSD-16717 ensure serviceAccount fields are nullified

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -108,6 +108,8 @@ objects:
                 name: service-ca
                 readOnly: true
             restartPolicy: Always
+            serviceAccount: ""
+            serviceAccountName: ""
             tolerations:
             - effect: NoSchedule
               key: node-role.kubernetes.io/master


### PR DESCRIPTION
# What it does

Ensures that the `serviceAccount` and `serviceAccountName` fields are nullified in the `DaemonSet` that gets distributed by the SelectorSyncSet.

# Why?

The removal of the ServiceAccount and associated references in [OSD-16717](https://issues.redhat.com//browse/OSD-16717) only worked partially, because the Hive ClusterSync does not remove the `serviceAccount` and `serviceAccountName` fields from the target Daemonset on the cluster. So it left them behind, whilst also deleting the `ServiceAccount`. Which means that pre-existing clusters in Staging are having a bad time.

To ensure that the fields properly get nullified on-cluster, we have to ensure they are set to empty-string in the SelectorSyncSet resource.

However, doing that is challenging, because these fields have `omitempty` set, so marshalling to yaml with an empty string just excludes them from the generated resource. So we need to intercept the marshalling to override the `omitempty` and re-set them to empty string. I really don't know any better way than what I'm doing in this PR, and we've already proven it works in a prior change. And once we've done this once, we can remove the code in a subsequent PR as it will no longer be necessary.

# refs

[OSD-16717](https://issues.redhat.com//browse/OSD-16717)