### PR TITLE
OSD-16762 allow system:admin to update SCCs

### DIFF
--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -39,6 +39,7 @@ var (
 	allowedUsers = []string{
 		"system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
 		"system:serviceaccount:openshift-cluster-version:default",
+		"system:admin",
 	}
 	allowedGroups = []string{}
 	defaultSCCs   = []string{

--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -143,6 +143,14 @@ func TestUserPositive(t *testing.T) {
 			shouldBeAllowed: true,
 		},
 		{
+			targetSCC:       "hostaccess",
+			testID:          "allowed-system-admin-can-modify-default",
+			username:        "system:admin",
+			operation:       admissionv1.Update,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed: true,
+		},
+		{
 			targetSCC:       "testscc",
 			testID:          "user-can-delete-normal",
 			username:        "user1",


### PR DESCRIPTION
# What it does

Allow the `system:admin` user to be able to UPDATE the default set of OpenShift SCCs.

# Why?

The `cluster-version-operator` in HCP namespaces uses `system:admin` to patch SCCs during upgrades, rather than the regular OCP user of `system:serviceaccount:openshift-monitoring:cluster-monitoring-operator`.  This then gets blocked by MCVW and is causing y-stream upgrades to fail.

# Refs

[OSD-16762](https://issues.redhat.com//browse/OSD-16762)