### PR TITLE
OSD-16717 Do not mount API token into MCVW pod

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -144,6 +144,7 @@ func createPackagedDeployment(replicas int32, phase string) *appsv1.Deployment {
 					},
 				},
 				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &[]bool{false}[0],
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -85,6 +85,7 @@ spec:
               matchLabels:
                 app: validation-webhook
             topologyKey: topology.kubernetes.io/zone
+      automountServiceAccountToken: false
       containers:
       - command:
         - webhooks


### PR DESCRIPTION
# What it does
Do not mount the API token into the `validation-webhooks` Deployment, as it is not necessary or used.

This change has been succesfully tested on HyperShift Hosted Clusters to verify that webhook protection still occurs.

# Why
Security hardening per [OSD-16717](https://issues.redhat.com//browse/OSD-16717)