### PR TITLE
Update ICP webhook documentation message

### DIFF
--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	WebhookName = "imagecontentpolicies-validation"
-	WebhookDoc  = "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for quay.io, registry.redhat.io, nor registry.access.redhat.com."
+	WebhookDoc  = "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for the entirety of quay.io, registry.redhat.io, nor registry.access.redhat.com. If needed, specific repositories can have mirrors configured, such as quay.io/example."
 	// unauthorizedRepositoryMirrors is a regex that is used to reject certain specified repository mirrors.
 	// Only registry.redhat.io exactly is blocked, while all other contained regexes
 	// follow a similar pattern, i.e. rejecting quay.io or quay.io/.*


### PR DESCRIPTION
It was unclear that customers are able to configure mirrors for specific repositories and only blocked from configuring mirrors across the entirety of certain domains.

[OSD-15757](https://issues.redhat.com//browse/OSD-15757)