### PR TITLE
[OSD-16224] add webhook to prevent critical serviceaccount deletion

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -511,6 +511,36 @@ objects:
         annotations:
           service.beta.openshift.io/inject-cabundle: "true"
         creationTimestamp: null
+        name: sre-serviceaccount-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /serviceaccount-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: serviceaccount-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - ""
+          apiVersions:
+          - v1
+          operations:
+          - DELETE
+          resources:
+          - serviceaccounts
+          scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 2
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        creationTimestamp: null
         name: sre-techpreviewnoupgrade-validation
       webhooks:
       - admissionReviewVersions:

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -382,6 +382,36 @@ metadata:
     package-operator.run/phase: webhooks
     service.beta.openshift.io/inject-cabundle: "false"
   creationTimestamp: null
+  name: sre-serviceaccount-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '{{.config.serviceca | b64enc }}'
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/serviceaccount-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: serviceaccount-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - serviceaccounts
+    scope: Namespaced
+  sideEffects: None
+  timeoutSeconds: 2
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  creationTimestamp: null
   name: sre-techpreviewnoupgrade-validation
 webhooks:
 - admissionReviewVersions:

--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -29,7 +29,7 @@
   },
   {
     "webhookName": "regular-user-validation",
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io machineconfiguration.openshift.io network.openshift.io managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io config.openshift.io operator.openshift.io cloudcredential.openshift.io cloudingress.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [cloudcredential.openshift.io machine.openshift.io admissionregistration.k8s.io operator.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io machineconfiguration.openshift.io managed.openshift.io ocmagent.managed.openshift.io network.openshift.io config.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io autoscaling.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "regular-user-validation-osd",
@@ -38,6 +38,10 @@
   {
     "webhookName": "scc-validation",
     "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork hostnetwork-v2 node-exporter nonroot nonroot-v2 privileged restricted restricted-v2]"
+  },
+  {
+    "webhookName": "serviceaccount-validation",
+    "documentString": "Managed OpenShift Customers may not delete the service accounts under the managed namespaces。"
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -318,7 +318,7 @@
         "scope": "*"
       }
     ],
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [addons.managed.openshift.io cloudingress.managed.openshift.io upgrade.managed.openshift.io autoscaling.openshift.io config.openshift.io operator.openshift.io machine.openshift.io managed.openshift.io ocmagent.managed.openshift.io machineconfiguration.openshift.io network.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io splunkforwarder.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [addons.managed.openshift.io ocmagent.managed.openshift.io operator.openshift.io network.openshift.io admissionregistration.k8s.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io config.openshift.io cloudcredential.openshift.io machine.openshift.io managed.openshift.io autoscaling.openshift.io machineconfiguration.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "regular-user-validation-osd",
@@ -363,6 +363,27 @@
       }
     ],
     "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork hostnetwork-v2 node-exporter nonroot nonroot-v2 privileged restricted restricted-v2]"
+  },
+  {
+    "webhookName": "serviceaccount-validation",
+    "rules": [
+      {
+        "operations": [
+          "DELETE"
+        ],
+        "apiGroups": [
+          ""
+        ],
+        "apiVersions": [
+          "v1"
+        ],
+        "resources": [
+          "serviceaccounts"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may not delete the service accounts under the managed namespaces。"
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -6,14 +6,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	responsehelper "github.com/openshift/managed-cluster-validating-webhooks/pkg/helpers"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 )
 
 // Webhook interface
@@ -54,7 +55,7 @@ func CanCanNot(b bool) string {
 func CreateFakeRequestJSON(uid string,
 	gvk metav1.GroupVersionKind, gvr metav1.GroupVersionResource,
 	operation admissionv1.Operation,
-	username string, userGroups []string,
+	username string, userGroups []string, namespace string,
 	obj, oldObject *runtime.RawExtension) ([]byte, error) {
 
 	req := admissionv1.AdmissionReview{
@@ -64,6 +65,7 @@ func CreateFakeRequestJSON(uid string,
 			RequestKind: &gvk,
 			Resource:    gvr,
 			Operation:   operation,
+			Namespace:   namespace,
 			UserInfo: authenticationv1.UserInfo{
 				Username: username,
 				Groups:   userGroups,
@@ -96,9 +98,9 @@ func CreateFakeRequestJSON(uid string,
 func CreateHTTPRequest(uri, uid string,
 	gvk metav1.GroupVersionKind, gvr metav1.GroupVersionResource,
 	operation admissionv1.Operation,
-	username string, userGroups []string,
+	username string, userGroups []string, namespace string,
 	obj, oldObject *runtime.RawExtension) (*http.Request, error) {
-	req, err := CreateFakeRequestJSON(uid, gvk, gvr, operation, username, userGroups, obj, oldObject)
+	req, err := CreateFakeRequestJSON(uid, gvk, gvr, operation, username, userGroups, namespace, obj, oldObject)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhooks/add_serviceaccount.go
+++ b/pkg/webhooks/add_serviceaccount.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/serviceaccount"
+)
+
+func init() {
+	Register(serviceaccount.WebhookName, func() Webhook { return serviceaccount.NewWebhook() })
+}

--- a/pkg/webhooks/clusterlogging/clusterlogging_test.go
+++ b/pkg/webhooks/clusterlogging/clusterlogging_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/clusterlogging"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/clusterlogging"
 )
 
 type clusterloggingTestSuite struct {
@@ -128,7 +129,7 @@ func runTests(t *testing.T, tests []clusterloggingTestSuite) {
 		hook := clusterlogging.NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
 			test.testID,
-			metav1.GroupVersionKind{}, metav1.GroupVersionResource{}, test.operation, test.username, test.userGroups, obj, test.oldObject)
+			metav1.GroupVersionKind{}, metav1.GroupVersionResource{}, test.operation, test.username, test.userGroups, "", obj, test.oldObject)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/clusterrolebinding/clusterrolebinding_test.go
+++ b/pkg/webhooks/clusterrolebinding/clusterrolebinding_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 	admissionv1 "k8s.io/api/admission/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -74,7 +75,7 @@ func runClusterRoleBindingTests(t *testing.T, tests []ClusterRoleBindingTestSuit
 
 		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
-			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, &oldObj)
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, "", &obj, &oldObj)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/hiveownership/hiveownership_test.go
+++ b/pkg/webhooks/hiveownership/hiveownership_test.go
@@ -67,7 +67,7 @@ func runTests(t *testing.T, tests []hiveOwnershipTestSuites) {
 		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
 			test.testID,
-			gvk, gvr, test.operation, test.username, test.userGroups, obj, test.oldObject)
+			gvk, gvr, test.operation, test.username, test.userGroups, "", obj, test.oldObject)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
@@ -7,11 +7,12 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 )
 
 func Test_authorizeImageDigestMirrorSet(t *testing.T) {
@@ -476,7 +477,7 @@ func TestImageContentPolicy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			hook := NewWebhook()
-			req, err := testutils.CreateHTTPRequest(hook.GetURI(), test.name, test.gvk, test.gvr, test.op, "", []string{}, test.obj, test.oldObj)
+			req, err := testutils.CreateHTTPRequest(hook.GetURI(), test.name, test.gvk, test.gvr, test.op, "", []string{}, "", test.obj, test.oldObj)
 			if err != nil {
 				t.Errorf("failed to create test HTTP request: %v", err)
 			}

--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -72,7 +72,7 @@ func runNamespaceTests(t *testing.T, tests []namespaceTestSuites) {
 		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
 			test.testID,
-			gvk, gvr, test.operation, test.username, test.userGroups, obj, test.oldObject)
+			gvk, gvr, test.operation, test.username, test.userGroups, "", obj, test.oldObject)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/pod/pod.go
+++ b/pkg/webhooks/pod/pod.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"sync"
 
-	hookconfig "github.com/openshift/managed-cluster-validating-webhooks/pkg/config"
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,6 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	hookconfig "github.com/openshift/managed-cluster-validating-webhooks/pkg/config"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
 )
 
 const (

--- a/pkg/webhooks/pod/pod_test.go
+++ b/pkg/webhooks/pod/pod_test.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 )
 
 func createRawPodJSON(name string, tolerations []corev1.Toleration, uid string, namespace string) (string, error) {
@@ -68,7 +69,7 @@ func runPodTests(t *testing.T, tests []podTestSuites) {
 
 		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
-			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, nil)
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, test.namespace, &obj, nil)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/prometheusrule/prometheusrule_test.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 )
 
 const testObjectRaw string = `
@@ -61,7 +62,7 @@ func runPrometheusRuleTests(t *testing.T, tests []prometheusruleTestSuites) {
 
 		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
-			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, &oldObj)
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, "", &obj, &oldObj)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/regularuser/common/regularuser_test.go
+++ b/pkg/webhooks/regularuser/common/regularuser_test.go
@@ -90,7 +90,7 @@ func runRegularuserTests(t *testing.T, tests []regularuserTests) {
 
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
 			test.testID,
-			gvk, gvr, test.operation, test.username, test.userGroups, &obj, test.oldObject)
+			gvk, gvr, test.operation, test.username, test.userGroups, test.targetNamespace, &obj, test.oldObject)
 		if err != nil {
 			t.Fatalf("%s Expected no error, got %s", test.testID, err.Error())
 		}

--- a/pkg/webhooks/regularuser/osd/regularuser_test.go
+++ b/pkg/webhooks/regularuser/osd/regularuser_test.go
@@ -90,7 +90,7 @@ func runRegularuserTests(t *testing.T, tests []regularuserTests) {
 
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
 			test.testID,
-			gvk, gvr, test.operation, test.username, test.userGroups, &obj, test.oldObject)
+			gvk, gvr, test.operation, test.username, test.userGroups, test.targetNamespace, &obj, test.oldObject)
 		if err != nil {
 			t.Fatalf("%s Expected no error, got %s", test.testID, err.Error())
 		}

--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -60,7 +61,7 @@ func runSCCTests(t *testing.T, tests []sccTestSuites) {
 
 		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
-			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, &oldObj)
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, "", &obj, &oldObj)
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}

--- a/pkg/webhooks/serviceaccount/serviceaccount.go
+++ b/pkg/webhooks/serviceaccount/serviceaccount.go
@@ -1,0 +1,221 @@
+package serviceaccount
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/config"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+)
+
+const (
+	WebhookName string = "serviceaccount-validation"
+	docString   string = `Managed OpenShift Customers may not delete the service accounts under the managed namespaces。`
+)
+
+var (
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+	scope         = admissionregv1.NamespacedScope
+	rules         = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"serviceaccounts"},
+				Scope:       &scope,
+			},
+		},
+	}
+	allowedUsers  []string
+	allowedGroups = []string{
+		"system:serviceaccounts:openshift-backplane-srep",
+	}
+	allowedServiceAccounts = []string{
+		"builder",
+		"default",
+		"deployer",
+	}
+	exceptionNamespaces = []string{
+		"openshift-logging",
+		"openshift-user-workload-monitoring",
+		"openshift-operators",
+	}
+)
+
+type serviceAccountWebhook struct {
+	s runtime.Scheme
+}
+
+// NewWebhook creates the new webhook
+func NewWebhook() *serviceAccountWebhook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to serviceAccountWebhook")
+		os.Exit(1)
+	}
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding corev1 scheme to serviceAccountWebhook")
+		os.Exit(1)
+	}
+
+	return &serviceAccountWebhook{
+		s: *scheme,
+	}
+}
+
+// Authorized implements Webhook interface
+func (s *serviceAccountWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+func (s *serviceAccountWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	sa, err := s.renderServiceAccount(request)
+	if err != nil {
+		log.Error(err, "Couldn't render a service account from the incoming request")
+		return admissionctl.Errored(http.StatusBadRequest, err)
+	}
+
+	if isProtectedNamespace(request) && !isAllowedUserGroup(request) {
+		if request.Operation == admissionv1.Delete && !isAllowedServiceAccount(sa) {
+			log.Info(fmt.Sprintf("Deleting operation detected on proteced serviceaccount: %v", sa.Name))
+			ret = admissionctl.Denied(fmt.Sprintf("Deleting protected service account under namespace %v is not allowed", request.Namespace))
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
+	}
+
+	ret = admissionctl.Allowed("Request is allowed")
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// renderServiceAccount render the serviceaccount object from the requests
+func (s *serviceAccountWebhook) renderServiceAccount(request admissionctl.Request) (*corev1.ServiceAccount, error) {
+	decoder, err := admissionctl.NewDecoder(&s.s)
+	if err != nil {
+		return nil, err
+	}
+	sa := &corev1.ServiceAccount{}
+
+	if len(request.OldObject.Raw) > 0 {
+		err = decoder.DecodeRaw(request.OldObject, sa)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return sa, nil
+}
+
+// isAllowedUserGroup checks if the user or group is allowed to perform the action
+func isAllowedUserGroup(request admissionctl.Request) bool {
+	if utils.SliceContains(request.UserInfo.Username, allowedUsers) {
+		return true
+	}
+
+	for _, group := range allowedGroups {
+		if utils.SliceContains(group, request.UserInfo.Groups) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isProtectedNamespace checks if the request is going to operate on the serviceaccount in the
+// protected namespace list
+func isProtectedNamespace(request admissionctl.Request) bool {
+	ns := request.Namespace
+
+	if config.IsPrivilegedNamespace(ns) && !utils.SliceContains(ns, exceptionNamespaces) {
+		return true
+	}
+	return false
+}
+
+func isAllowedServiceAccount(sa *corev1.ServiceAccount) bool {
+	for _, s := range allowedServiceAccounts {
+		if sa.Name == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetURI implements Webhook interface
+func (s *serviceAccountWebhook) GetURI() string {
+	return "/" + WebhookName
+}
+
+// Validate implements Webhook interface
+func (s *serviceAccountWebhook) Validate(request admissionctl.Request) bool {
+	valid := true
+	valid = valid && (request.UserInfo.Username != "")
+	valid = valid && (request.Kind.Kind == "ServiceAccount")
+
+	return valid
+}
+
+// Name implements Webhook interface
+func (s *serviceAccountWebhook) Name() string {
+	return WebhookName
+}
+
+// FailurePolicy implements Webhook interface
+func (s *serviceAccountWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// MatchPolicy implements Webhook interface
+func (s *serviceAccountWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Rules implements Webhook interface
+func (s *serviceAccountWebhook) Rules() []admissionregv1.RuleWithOperations {
+	return rules
+}
+
+// ObjectSelector implements Webhook interface
+func (s *serviceAccountWebhook) ObjectSelector() *metav1.LabelSelector {
+	return nil
+}
+
+// SideEffects implements Webhook interface
+func (s *serviceAccountWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *serviceAccountWebhook) TimeoutSeconds() int32 {
+	return timeout
+}
+
+// Doc implements Webhook interface
+func (s *serviceAccountWebhook) Doc() string {
+	return fmt.Sprintf(docString)
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+// Return utils.DefaultLabelSelector() to stick with the default
+func (s *serviceAccountWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	return utils.DefaultLabelSelector()
+}
+
+func (s *serviceAccountWebhook) HypershiftEnabled() bool { return true }

--- a/pkg/webhooks/serviceaccount/serviceaccount_test.go
+++ b/pkg/webhooks/serviceaccount/serviceaccount_test.go
@@ -1,0 +1,132 @@
+package serviceaccount
+
+import (
+	"fmt"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+)
+
+type serviceAccountTestSuites struct {
+	testID          string
+	targetSA        string
+	username        string
+	operation       admissionv1.Operation
+	userGroups      []string
+	namespace       string
+	shouldBeAllowed bool
+}
+
+const testObjectRaw string = `
+{
+	"apiVersion": "v1",
+	"kind": "ServiceAccount",
+	"metadata": {
+		"name": "%s",
+		"namespace": "%s",
+		"uid": "1234"
+	}
+}`
+
+func createRawJSONString(name, namespace string) string {
+	s := fmt.Sprintf(testObjectRaw, name, namespace)
+	return s
+}
+
+func runServiceAccountTests(t *testing.T, tests []serviceAccountTestSuites) {
+	gvk := metav1.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "ServiceAccount",
+	}
+	gvr := metav1.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "serviceaccounts",
+	}
+
+	for _, test := range tests {
+		rawObjString := createRawJSONString(test.targetSA, test.namespace)
+
+		obj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		oldObj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		hook := NewWebhook()
+		httpRequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, test.namespace, &obj, &oldObj)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+
+		response, err := testutils.SendHTTPRequest(httpRequest, hook)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+		if response.UID == "" {
+			t.Fatalf("No tracking UID associated with the response.")
+		}
+
+		if response.Allowed != test.shouldBeAllowed {
+			t.Fatalf("Mismatch: %s (groups=%s) %s %s the serviceaccount. Test's expectation is that the user %s", test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
+		}
+	}
+}
+func TestSADeletion(t *testing.T) {
+	tests := []serviceAccountTestSuites{
+		{
+			targetSA:        "whatever",
+			testID:          "user-cant-delete-protected-sa-in-protected-ns",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-ingress-operator",
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: false,
+		},
+		{
+			targetSA:        "default",
+			testID:          "user-can-delete-normal-sa-in-protected-ns",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-ingress-operator",
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "whatever",
+			testID:          "user-can-delete-sa-in-normal-ns",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "whatever",
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "whatever",
+			testID:          "user-can-delete-sa-in-exception-ns",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-operators",
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "whatever",
+			testID:          "sre-can-delete-sa-in-protected-ns",
+			username:        "user1",
+			operation:       admissionv1.Delete,
+			userGroups:      []string{"system:serviceaccounts:openshift-backplane-srep"},
+			namespace:       "openshift-ingress-operator",
+			shouldBeAllowed: true,
+		},
+	}
+	runServiceAccountTests(t, tests)
+}

--- a/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade_test.go
+++ b/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/techpreviewnoupgrade"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/techpreviewnoupgrade"
 )
 
 type techpreviewnoupgradeTestSuite struct {
@@ -88,7 +89,7 @@ func runTests(t *testing.T, tests []techpreviewnoupgradeTestSuite) {
 		}
 
 		hook := techpreviewnoupgrade.NewWebhook()
-		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(), test.testID, metav1.GroupVersionKind{}, metav1.GroupVersionResource{}, test.operation, test.username, test.userGroups, &obj, nil) // we are only worried about the introduction of the featureSet
+		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(), test.testID, metav1.GroupVersionKind{}, metav1.GroupVersionResource{}, test.operation, test.username, test.userGroups, "", &obj, nil) // we are only worried about the introduction of the featureSet
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %s", err.Error())


### PR DESCRIPTION
Add the webhook for critical serviceccount deletion prevention
update the testutils to include the namespace value in the request