### PR TITLE
[OSD-16225] : Add clusterrolebinding webhooks to prevent deletion of clusterrolebings in openshift and kube-system namespace

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -137,6 +137,36 @@ objects:
         annotations:
           service.beta.openshift.io/inject-cabundle: "true"
         creationTimestamp: null
+        name: sre-clusterrolebindings-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /clusterrolebindings-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: clusterrolebindings-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          apiVersions:
+          - v1
+          operations:
+          - DELETE
+          resources:
+          - clusterrolebindings
+          scope: Cluster
+        sideEffects: None
+        timeoutSeconds: 2
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        creationTimestamp: null
         name: sre-hiveownership-validation
       webhooks:
       - admissionReviewVersions:

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -135,6 +135,36 @@ metadata:
     package-operator.run/phase: webhooks
     service.beta.openshift.io/inject-cabundle: "false"
   creationTimestamp: null
+  name: sre-clusterrolebindings-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '{{.config.serviceca | b64enc }}'
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/clusterrolebindings-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: clusterrolebindings-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - clusterrolebindings
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 2
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  creationTimestamp: null
   name: sre-imagecontentpolicies-validation
 webhooks:
 - admissionReviewVersions:

--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -4,8 +4,16 @@
     "documentString": "Managed OpenShift Customers may set log retention outside the allowed range of 0-7 days"
   },
   {
+    "webhookName": "clusterrolebindings-validation",
+    "documentString": "Managed OpenShift Customers may not delete the cluster role bindings under the managed namespaces: (^openshift-.*|kube-system)"
+  },
+  {
     "webhookName": "hiveownership-validation",
     "documentString": "Managed OpenShift customers may not edit certain managed resources. A managed resource has a \"hive.openshift.io/managed\": \"true\" label."
+  },
+  {
+    "webhookName": "imagecontentpolicies-validation",
+    "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for the entirety of quay.io, registry.redhat.io, nor registry.access.redhat.com. If needed, specific repositories can have mirrors configured, such as quay.io/example."
   },
   {
     "webhookName": "namespace-validation",
@@ -16,12 +24,20 @@
     "documentString": "Managed OpenShift Customers may use tolerations on Pods that could cause those Pods to be scheduled on infra or master nodes."
   },
   {
+    "webhookName": "prometheusrule-validation",
+    "documentString": "Managed OpenShift Customers may not create PrometheusRule in namespaces managed by Red Hat."
+  },
+  {
     "webhookName": "regular-user-validation",
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [autoscaling.openshift.io config.openshift.io operator.openshift.io network.openshift.io machine.openshift.io admissionregistration.k8s.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io ocmagent.managed.openshift.io cloudcredential.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io machineconfiguration.openshift.io network.openshift.io managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io config.openshift.io operator.openshift.io cloudcredential.openshift.io cloudingress.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+  },
+  {
+    "webhookName": "regular-user-validation-osd",
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [], nor may Managed OpenShift customers alter the Node objects."
   },
   {
     "webhookName": "scc-validation",
-    "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork node-exporter nonroot privileged restricted]"
+    "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork hostnetwork-v2 node-exporter nonroot nonroot-v2 privileged restricted restricted-v2]"
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -22,6 +22,27 @@
     "documentString": "Managed OpenShift Customers may set log retention outside the allowed range of 0-7 days"
   },
   {
+    "webhookName": "clusterrolebindings-validation",
+    "rules": [
+      {
+        "operations": [
+          "DELETE"
+        ],
+        "apiGroups": [
+          "rbac.authorization.k8s.io"
+        ],
+        "apiVersions": [
+          "v1"
+        ],
+        "resources": [
+          "clusterrolebindings"
+        ],
+        "scope": "Cluster"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may not delete the cluster role bindings under the managed namespaces: (^openshift-.*|kube-system)"
+  },
+  {
     "webhookName": "hiveownership-validation",
     "rules": [
       {
@@ -47,6 +68,45 @@
       }
     },
     "documentString": "Managed OpenShift customers may not edit certain managed resources. A managed resource has a \"hive.openshift.io/managed\": \"true\" label."
+  },
+  {
+    "webhookName": "imagecontentpolicies-validation",
+    "rules": [
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE"
+        ],
+        "apiGroups": [
+          "config.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "imagedigestmirrorsets",
+          "imagetagmirrorsets"
+        ],
+        "scope": "Cluster"
+      },
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE"
+        ],
+        "apiGroups": [
+          "operator.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "imagecontentsourcepolicies"
+        ],
+        "scope": "Cluster"
+      }
+    ],
+    "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for the entirety of quay.io, registry.redhat.io, nor registry.access.redhat.com. If needed, specific repositories can have mirrors configured, such as quay.io/example."
   },
   {
     "webhookName": "namespace-validation",
@@ -91,6 +151,29 @@
       }
     ],
     "documentString": "Managed OpenShift Customers may use tolerations on Pods that could cause those Pods to be scheduled on infra or master nodes."
+  },
+  {
+    "webhookName": "prometheusrule-validation",
+    "rules": [
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE",
+          "DELETE"
+        ],
+        "apiGroups": [
+          "monitoring.coreos.com"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "prometheusrules"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Managed OpenShift Customers may not create PrometheusRule in namespaces managed by Red Hat."
   },
   {
     "webhookName": "regular-user-validation",
@@ -148,7 +231,41 @@
           "clusterversions",
           "clusterversions/status",
           "schedulers",
-          "apiservers"
+          "apiservers",
+          "proxies"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE",
+          "DELETE"
+        ],
+        "apiGroups": [
+          ""
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "configmaps"
+        ],
+        "scope": "*"
+      },
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          "machineconfiguration.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "machineconfigs",
+          "machineconfigpools"
         ],
         "scope": "*"
       },
@@ -165,22 +282,6 @@
         "resources": [
           "kubeapiservers",
           "openshiftapiservers"
-        ],
-        "scope": "*"
-      },
-      {
-        "operations": [
-          "*"
-        ],
-        "apiGroups": [
-          ""
-        ],
-        "apiVersions": [
-          "*"
-        ],
-        "resources": [
-          "nodes",
-          "nodes/*"
         ],
         "scope": "*"
       },
@@ -217,7 +318,29 @@
         "scope": "*"
       }
     ],
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [network.openshift.io cloudcredential.openshift.io managed.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io config.openshift.io operator.openshift.io machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Node or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [addons.managed.openshift.io cloudingress.managed.openshift.io upgrade.managed.openshift.io autoscaling.openshift.io config.openshift.io operator.openshift.io machine.openshift.io managed.openshift.io ocmagent.managed.openshift.io machineconfiguration.openshift.io network.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io splunkforwarder.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+  },
+  {
+    "webhookName": "regular-user-validation-osd",
+    "rules": [
+      {
+        "operations": [
+          "*"
+        ],
+        "apiGroups": [
+          ""
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "nodes",
+          "nodes/*"
+        ],
+        "scope": "*"
+      }
+    ],
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [], nor may Managed OpenShift customers alter the Node objects."
   },
   {
     "webhookName": "scc-validation",
@@ -239,7 +362,7 @@
         "scope": "Cluster"
       }
     ],
-    "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork node-exporter nonroot privileged restricted]"
+    "documentString": "Managed OpenShift Customers may not modify the following default SCCs: [anyuid hostaccess hostmount-anyuid hostnetwork hostnetwork-v2 node-exporter nonroot nonroot-v2 privileged restricted restricted-v2]"
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",

--- a/pkg/webhooks/add_clusterrolebinding.go
+++ b/pkg/webhooks/add_clusterrolebinding.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/clusterrolebinding"
+)
+
+func init() {
+	Register(clusterrolebinding.WebhookName, func() Webhook { return clusterrolebinding.NewWebhook() })
+}

--- a/pkg/webhooks/clusterrolebinding/clusterrolebinding.go
+++ b/pkg/webhooks/clusterrolebinding/clusterrolebinding.go
@@ -1,0 +1,200 @@
+package clusterrolebinding
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName       string = "clusterrolebindings-validation"
+	docString         string = `Managed OpenShift Customers may not delete the cluster role bindings under the managed namespaces: %s`
+	managedNamespaces string = `(^openshift-.*|kube-system)`
+)
+
+var (
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+	scope         = admissionregv1.ClusterScope
+	rules         = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"rbac.authorization.k8s.io"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"clusterrolebindings"},
+				Scope:       &scope,
+			},
+		},
+	}
+
+	protectedNamespaces = regexp.MustCompile(managedNamespaces)
+
+	exceptionNamespaces = []string{
+		"openshift-logging",
+		"openshift-user-workload-monitoring",
+		"openshift-operators",
+	}
+)
+
+type ClusterRoleBindingWebHook struct {
+	s runtime.Scheme
+}
+
+// NewWebhook creates the new webhook
+func NewWebhook() *ClusterRoleBindingWebHook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to ClusterRoleBindingWebHook")
+		os.Exit(1)
+	}
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding corev1 scheme to ClusterRoleBindingWebHook")
+		os.Exit(1)
+	}
+
+	return &ClusterRoleBindingWebHook{
+		s: *scheme,
+	}
+}
+
+// Authorized implements Webhook interface
+func (s *ClusterRoleBindingWebHook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+func (s *ClusterRoleBindingWebHook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	clusterRoleBinding, err := s.renderClusterRoleBinding(request)
+	if err != nil {
+		log.Error(err, "Couldn't render a ClusterRoleBinding from the incoming request")
+		return admissionctl.Errored(http.StatusBadRequest, err)
+	}
+
+	log.Info(fmt.Sprintf("Found clusterrolebinding: %v", clusterRoleBinding.Name))
+
+	if isProtectedNamespace(clusterRoleBinding) {
+		switch request.Operation {
+		case admissionv1.Delete:
+			log.Info(fmt.Sprintf("Deleting operation detected on ClusterRoleBinding: %v", clusterRoleBinding.Name))
+			ret = admissionctl.Denied(fmt.Sprintf("Deleting ClusterRoleBinding %v is not allowed", clusterRoleBinding.Name))
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
+	}
+
+	ret = admissionctl.Allowed("Request is allowed")
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// renderSCC render the SCC object from the requests
+func (s *ClusterRoleBindingWebHook) renderClusterRoleBinding(request admissionctl.Request) (*rbacv1.ClusterRoleBinding, error) {
+	decoder, err := admissionctl.NewDecoder(&s.s)
+	if err != nil {
+		return nil, err
+	}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+
+	if len(request.OldObject.Raw) > 0 {
+		err = decoder.DecodeRaw(request.OldObject, clusterRoleBinding)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterRoleBinding, nil
+}
+
+// isProtectedNamespace returns true if clusterRoleBinding subject link
+// to ServiceAccount and openshift-*|kube-system ns
+func isProtectedNamespace(clusterRoleBinding *rbacv1.ClusterRoleBinding) bool {
+	isProtectNs := false
+
+	for _, subject := range clusterRoleBinding.Subjects {
+		if subject.Kind == "ServiceAccount" {
+			ns := subject.Namespace
+			if protectedNamespaces.Match([]byte(ns)) && !utils.SliceContains(ns, exceptionNamespaces) {
+				isProtectNs = true
+			}
+		}
+	}
+
+	return isProtectNs
+}
+
+// GetURI implements Webhook interface
+func (s *ClusterRoleBindingWebHook) GetURI() string {
+	return "/" + WebhookName
+}
+
+// Validate implements Webhook interface
+func (s *ClusterRoleBindingWebHook) Validate(request admissionctl.Request) bool {
+	valid := true
+	valid = valid && (request.UserInfo.Username != "")
+	valid = valid && (request.Kind.Kind == "ClusterRoleBinding")
+
+	return valid
+}
+
+// Name implements Webhook interface
+func (s *ClusterRoleBindingWebHook) Name() string {
+	return WebhookName
+}
+
+// FailurePolicy implements Webhook interface
+func (s *ClusterRoleBindingWebHook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// MatchPolicy implements Webhook interface
+func (s *ClusterRoleBindingWebHook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Rules implements Webhook interface
+func (s *ClusterRoleBindingWebHook) Rules() []admissionregv1.RuleWithOperations {
+	return rules
+}
+
+// ObjectSelector implements Webhook interface
+func (s *ClusterRoleBindingWebHook) ObjectSelector() *metav1.LabelSelector {
+	return nil
+}
+
+// SideEffects implements Webhook interface
+func (s *ClusterRoleBindingWebHook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *ClusterRoleBindingWebHook) TimeoutSeconds() int32 {
+	return timeout
+}
+
+// Doc implements Webhook interface
+func (s *ClusterRoleBindingWebHook) Doc() string {
+	return fmt.Sprintf(docString, managedNamespaces)
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+// Return utils.DefaultLabelSelector() to stick with the default
+func (s *ClusterRoleBindingWebHook) SyncSetLabelSelector() metav1.LabelSelector {
+	return utils.DefaultLabelSelector()
+}
+
+func (s *ClusterRoleBindingWebHook) HypershiftEnabled() bool { return true }

--- a/pkg/webhooks/clusterrolebinding/clusterrolebinding_test.go
+++ b/pkg/webhooks/clusterrolebinding/clusterrolebinding_test.go
@@ -1,0 +1,195 @@
+package clusterrolebinding
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	admissionv1 "k8s.io/api/admission/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type ClusterRoleBindingTestSuites struct {
+	testID                   string
+	targetClusterRoleBinding string
+	subjects                 []rbacv1.Subject
+	username                 string
+	operation                admissionv1.Operation
+	userGroups               []string
+	shouldBeAllowed          bool
+}
+
+const testObjectRaw string = `
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "ClusterRoleBinding",
+	"metadata": {
+		"name": "%s",
+		"uid": "1234"
+	},
+	"subjects": %s
+}`
+
+func createRawJSONString(
+	name string,
+	subjects []rbacv1.Subject,
+) (string, error) {
+	partial, err := json.Marshal(subjects)
+	return fmt.Sprintf(testObjectRaw, name, string(partial)), err
+}
+
+func runClusterRoleBindingTests(t *testing.T, tests []ClusterRoleBindingTestSuites) {
+	gvk := metav1.GroupVersionKind{
+		Group:   "rbac.authorization.k8s.io",
+		Version: "v1",
+		Kind:    "ClusterRoleBinding",
+	}
+	gvr := metav1.GroupVersionResource{
+		Group:    "rbac.authorization.k8s.io",
+		Version:  "v1",
+		Resource: "ClusterRoleBinding",
+	}
+
+	for _, test := range tests {
+		rawObjString, err := createRawJSONString(
+			test.targetClusterRoleBinding,
+			test.subjects,
+		)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+
+		obj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		oldObj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		hook := NewWebhook()
+		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(),
+			test.testID, gvk, gvr, test.operation, test.username, test.userGroups, &obj, &oldObj)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+
+		response, err := testutils.SendHTTPRequest(httprequest, hook)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+		if response.UID == "" {
+			t.Fatalf("No tracking UID associated with the response.")
+		}
+
+		if response.Allowed != test.shouldBeAllowed {
+			t.Fatalf("Mismatch: %s (groups=%s) %s %s the clusterrolebinding. Test's expectation is that the user %s", test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
+		}
+	}
+}
+func TestClusterRoleBindingDeletionNegative(t *testing.T) {
+	tests := []ClusterRoleBindingTestSuites{
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "user-cant-delete-protected-cluster-role-binding-in-protected-openshift-ns",
+			username:                 "user1",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed:          false,
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "openshift-ingress-operator",
+				},
+			},
+		},
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "user-cant-delete-protected-cluster-role-binding-in-protected-kube-system-ns",
+			username:                 "user1",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed:          false,
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "kube-system",
+				},
+			},
+		},
+	}
+	runClusterRoleBindingTests(t, tests)
+}
+
+func TestClusterRoleBindingDeletionPositive(t *testing.T) {
+	tests := []ClusterRoleBindingTestSuites{
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "user-can-delete-cluster-role-binding-in-non-protected-ns",
+			username:                 "user1",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed:          true,
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "whatever",
+				},
+			},
+		},
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "user-can-delete-cluster-role-binding-in-non-namespace-subject",
+			username:                 "user1",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed:          true,
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "User",
+					Name:      "whatever",
+					Namespace: "",
+				},
+			},
+		},
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "user-can-modify-cluster-role-binding-in-protected-ns",
+			username:                 "user1",
+			operation:                admissionv1.Update,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed:          true,
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "openshift-ingress-operator",
+				},
+			},
+		},
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "user-can-modify-cluster-role-binding-in-exception-ns",
+			username:                 "user1",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			shouldBeAllowed:          true,
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "openshift-operators",
+				},
+			},
+		},
+	}
+	runClusterRoleBindingTests(t, tests)
+}


### PR DESCRIPTION
Add the webhook for critical clusterrolebinding deletion prevention in following NS 

- openshift-*
- kube-system