### PR TITLE
Enable FIPS and switch to golang-1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ IMG_ORG ?= app-sre
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/${BASE_IMG}
 PKG_IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/${BASE_PKG_IMG}
 
-SYNCSET_GENERATOR_IMAGE := registry.ci.openshift.org/openshift/release:golang-1.18
+SYNCSET_GENERATOR_IMAGE := registry.ci.openshift.org/openshift/release:golang-1.19
 
 BINARY_FILE ?= build/_output/webhooks
 
@@ -28,9 +28,9 @@ unexport GOFLAGS
 GOOS?=linux
 GOARCH?=amd64
 GOFLAGS_MOD?=-mod=mod
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOFLAGS=${GOFLAGS_MOD}
 
-GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}" -tags="fips_enabled"
 
 # do not include this comma-separated list of hooks into the syncset
 SELECTOR_SYNC_SET_HOOK_EXCLUDES ?= debug-hook

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir

--- a/cmd/fips.go
+++ b/cmd/fips.go
@@ -1,0 +1,16 @@
+//go:build fips_enabled
+// +build fips_enabled
+
+// BOILERPLATE GENERATED -- DO NOT EDIT
+// Run 'make ensure-fips' to regenerate
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
- Switch to golang 1.19 for building MCVW and the selectorsyncset resources.
- Ensure that MCVW runs with FIPS enabled so that it is consistent with other OSD operators and workloads.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

