### PR TITLE
OSD-16469 - Add ingress controller webhook

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -243,6 +243,38 @@ objects:
         annotations:
           service.beta.openshift.io/inject-cabundle: "true"
         creationTimestamp: null
+        name: sre-ingresscontroller-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /ingresscontroller-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: ingresscontroller-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - operator.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - CREATE
+          - UPDATE
+          resources:
+          - ingresscontroller
+          - ingresscontrollers
+          scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 1
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        creationTimestamp: null
         name: sre-namespace-validation
       webhooks:
       - admissionReviewVersions:

--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -16,6 +16,10 @@
     "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for the entirety of quay.io, registry.redhat.io, nor registry.access.redhat.com. If needed, specific repositories can have mirrors configured, such as quay.io/example."
   },
   {
+    "webhookName": "ingresscontroller-validation",
+    "documentString": "Managed OpenShift Customer may create IngressControllers without necessary taints. This can cause those workloads to be provisioned on infra or master nodes."
+  },
+  {
     "webhookName": "namespace-validation",
     "documentString": "Managed OpenShift Customers may not modify namespaces specified in the [openshift-monitoring/addons-namespaces openshift-monitoring/managed-namespaces openshift-monitoring/ocp-namespaces] ConfigMaps because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression (^com$|^io$|^in$) because it could interfere with critical DNS resolution. Additionally, customers may not set or change the values of these Namespace labels [managed.openshift.io/storage-pv-quota-exempt managed.openshift.io/service-lb-quota-exempt]."
   },
@@ -29,7 +33,7 @@
   },
   {
     "webhookName": "regular-user-validation",
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [cloudcredential.openshift.io machine.openshift.io admissionregistration.k8s.io operator.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io machineconfiguration.openshift.io managed.openshift.io ocmagent.managed.openshift.io network.openshift.io config.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io autoscaling.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [autoscaling.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io ocmagent.managed.openshift.io upgrade.managed.openshift.io machine.openshift.io managed.openshift.io operator.openshift.io splunkforwarder.managed.openshift.io network.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io config.openshift.io machineconfiguration.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "regular-user-validation-osd",

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -109,6 +109,29 @@
     "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for the entirety of quay.io, registry.redhat.io, nor registry.access.redhat.com. If needed, specific repositories can have mirrors configured, such as quay.io/example."
   },
   {
+    "webhookName": "ingresscontroller-validation",
+    "rules": [
+      {
+        "operations": [
+          "CREATE",
+          "UPDATE"
+        ],
+        "apiGroups": [
+          "operator.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "ingresscontroller",
+          "ingresscontrollers"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Managed OpenShift Customer may create IngressControllers without necessary taints. This can cause those workloads to be provisioned on infra or master nodes."
+  },
+  {
     "webhookName": "namespace-validation",
     "rules": [
       {
@@ -318,7 +341,7 @@
         "scope": "*"
       }
     ],
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [addons.managed.openshift.io ocmagent.managed.openshift.io operator.openshift.io network.openshift.io admissionregistration.k8s.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io config.openshift.io cloudcredential.openshift.io machine.openshift.io managed.openshift.io autoscaling.openshift.io machineconfiguration.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIgroups [operator.openshift.io splunkforwarder.managed.openshift.io config.openshift.io upgrade.managed.openshift.io autoscaling.openshift.io machineconfiguration.openshift.io network.openshift.io cloudcredential.openshift.io managed.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io ocmagent.managed.openshift.io machine.openshift.io admissionregistration.k8s.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "regular-user-validation-osd",

--- a/pkg/webhooks/add_ingresscontroller.go
+++ b/pkg/webhooks/add_ingresscontroller.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/ingresscontroller"
+)
+
+func init() {
+	Register(ingresscontroller.WebhookName, func() Webhook { return ingresscontroller.NewWebhook() })
+}

--- a/pkg/webhooks/ingresscontroller/ingresscontroller.go
+++ b/pkg/webhooks/ingresscontroller/ingresscontroller.go
@@ -1,0 +1,187 @@
+package ingresscontroller
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	WebhookName string = "ingresscontroller-validation"
+	docString   string = `Managed OpenShift Customer may create IngressControllers without necessary taints. This can cause those workloads to be provisioned on infra or master nodes.`
+)
+
+var (
+	log   = logf.Log.WithName(WebhookName)
+	scope = admissionregv1.NamespacedScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"operator.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"ingresscontroller", "ingresscontrollers"},
+				Scope:       &scope,
+			},
+		},
+	}
+	allowedUsers = []string{
+		"backplane-cluster-admin",
+	}
+)
+
+type IngressControllerWebhook struct {
+	s runtime.Scheme
+}
+
+// ObjectSelector implements Webhook interface
+func (wh *IngressControllerWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
+func (wh *IngressControllerWebhook) Doc() string {
+	return fmt.Sprintf(docString)
+}
+
+// TimeoutSeconds implements Webhook interface
+func (wh *IngressControllerWebhook) TimeoutSeconds() int32 { return 1 }
+
+// MatchPolicy implements Webhook interface
+func (wh *IngressControllerWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Name implements Webhook interface
+func (wh *IngressControllerWebhook) Name() string { return WebhookName }
+
+// FailurePolicy implements Webhook interface and defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are Ignore or Fail.
+// Ignore means that an error calling the webhook is ignored and the API request is allowed to continue.
+// It's important to leave the FailurePolicy set to Ignore because otherwise the pod will fail to be created as the API request will be rejected.
+func (wh *IngressControllerWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// Rules implements Webhook interface
+func (wh *IngressControllerWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// GetURI implements Webhook interface
+func (wh *IngressControllerWebhook) GetURI() string { return "/" + WebhookName }
+
+// SideEffects implements Webhook interface
+func (wh *IngressControllerWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// Validate implements Webhook interface
+func (wh *IngressControllerWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "IngressController")
+
+	return valid
+}
+
+func (wh *IngressControllerWebhook) renderIngressController(req admissionctl.Request) (*operatorv1.IngressController, error) {
+	decoder, err := admissionctl.NewDecoder(&wh.s)
+	if err != nil {
+		return nil, err
+	}
+	ic := &operatorv1.IngressController{}
+	err = decoder.DecodeRaw(req.Object, ic)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ic, nil
+}
+
+func (wh *IngressControllerWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+	ic, err := wh.renderIngressController(request)
+	if err != nil {
+		log.Error(err, "Couldn't render an IngressController from the incoming request")
+		return admissionctl.Errored(http.StatusBadRequest, err)
+	}
+
+	log.Info("Checking if user is unauthenticated")
+	if request.AdmissionRequest.UserInfo.Username == "system:unauthenticated" {
+		// This could highlight a significant problem with RBAC since an
+		// unauthenticated user should have no permissions.
+		log.Info("system:unauthenticated made a webhook request. Check RBAC rules", "request", request.AdmissionRequest)
+		ret = admissionctl.Denied("Unauthenticated")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	log.Info("Checking if user is authenticated system: user")
+	if strings.HasPrefix(request.AdmissionRequest.UserInfo.Username, "system:") {
+		ret = admissionctl.Allowed("authenticated system: users are allowed")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	log.Info("Checking if user is kube: user")
+	if strings.HasPrefix(request.AdmissionRequest.UserInfo.Username, "kube:") {
+		ret = admissionctl.Allowed("kube: users are allowed")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// Check if the group does not have exceptions
+	if !isAllowedUser(request) {
+		for _, toleration := range ic.Spec.NodePlacement.Tolerations {
+			if strings.Contains(toleration.Key, "node-role.kubernetes.io/master") || strings.Contains(toleration.Key, "node-role.kubernetes.io/infra") {
+				ret = admissionctl.Denied("Not allowed to provision ingress controller pods with toleration for master and infra nodes.")
+				ret.UID = request.AdmissionRequest.UID
+
+				return ret
+			}
+		}
+	}
+
+	ret = admissionctl.Allowed("IngressController operation is allowed")
+	ret.UID = request.AdmissionRequest.UID
+
+	return ret
+}
+
+// isAllowedUser checks if the user is allowed to perform the action
+func isAllowedUser(request admissionctl.Request) bool {
+	log.Info(fmt.Sprintf("Checking username %s on whitelist", request.UserInfo.Username))
+	if utils.SliceContains(request.UserInfo.Username, allowedUsers) {
+		log.Info(fmt.Sprintf("%s is listed in whitelist", request.UserInfo.Username))
+		return true
+	}
+
+	log.Info("No allowed user found")
+
+	return false
+}
+
+// Authorized implements Webhook interface
+func (wh *IngressControllerWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return wh.authorized(request)
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+func (s *IngressControllerWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	return utils.DefaultLabelSelector()
+}
+
+func (s *IngressControllerWebhook) HypershiftEnabled() bool { return false }
+
+// NewWebhook creates a new webhook
+func NewWebhook() *IngressControllerWebhook {
+	scheme := runtime.NewScheme()
+	return &IngressControllerWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/ingresscontroller/ingresscontroller_test.go
+++ b/pkg/webhooks/ingresscontroller/ingresscontroller_test.go
@@ -1,0 +1,364 @@
+package ingresscontroller
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const template string = `{
+    "apiVersion": "operator.openshift.io/v1",
+    "kind": "IngressController",
+    "metadata": {
+        "name": "%s",
+        "namespace": "%s"
+    },
+    "spec": {
+        "clientTLS": {
+            "clientCA": {
+                "name": ""
+            },
+            "clientCertificatePolicy": ""
+        },
+        "defaultCertificate": {
+            "name": "dummy-default-cert"
+        },
+        "domain": "apps.dummy.devshift.org",
+        "endpointPublishingStrategy": {
+            "loadBalancer": {
+                "providerParameters": {
+                    "aws": {
+                        "classicLoadBalancer": {
+                            "connectionIdleTimeout": "30m0s"
+                        },
+                        "type": "Classic"
+                    },
+                    "type": "AWS"
+                },
+                "scope": "External"
+            },
+            "type": "LoadBalancerService"
+        },
+        "httpCompression": {},
+        "httpEmptyRequestsPolicy": "Respond",
+        "httpErrorCodePages": {
+            "name": ""
+        },
+        "nodePlacement": {
+            "nodeSelector": %s,
+            "tolerations": %s
+        },
+        "replicas": 2,
+        "routeSelector": {},
+        "tuningOptions": {}
+    }
+  }
+  `
+
+func createRawIngressControllerJSON(name string, namespace string, nodeSelector corev1.NodeSelector, tolerations []corev1.Toleration) (string, error) {
+	nodeSelectorPartial, err := json.Marshal(nodeSelector)
+	if err != nil {
+		return "", err
+	}
+	tolerationsPartial, err := json.Marshal(tolerations)
+	if err != nil {
+		return "", err
+	}
+
+	output := fmt.Sprintf(template, name, namespace, string(nodeSelectorPartial), string(tolerationsPartial))
+
+	return output, nil
+}
+
+type ingressControllerTestSuites struct {
+	testID          string
+	name            string
+	namespace       string
+	username        string
+	userGroups      []string
+	operation       admissionv1.Operation
+	nodeSelector    corev1.NodeSelector
+	tolerations     []corev1.Toleration
+	shouldBeAllowed bool
+}
+
+func runIngressControllerTests(t *testing.T, tests []ingressControllerTestSuites) {
+	gvk := metav1.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "IngressController",
+	}
+	gvr := metav1.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "ingresscontroller",
+	}
+	for _, test := range tests {
+		rawObjString, err := createRawIngressControllerJSON(test.name, test.namespace, test.nodeSelector, test.tolerations)
+		if err != nil {
+			t.Fatalf("Couldn't create a JSON fragment %s", err.Error())
+		}
+
+		obj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		oldObj := runtime.RawExtension{
+			Raw: []byte(rawObjString),
+		}
+
+		hook := NewWebhook()
+		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(), test.testID, gvk, gvr, test.operation, test.username, test.userGroups, "", &obj, &oldObj)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+
+		response, err := testutils.SendHTTPRequest(httprequest, hook)
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err.Error())
+		}
+		if response.UID == "" {
+			t.Fatalf("No tracking UID associated with the response.")
+		}
+
+		if response.Allowed != test.shouldBeAllowed {
+			t.Fatalf("[%s] Mismatch: %s (groups=%s) %s %s the ingress controller. Test's expectation is that the user %s", test.testID, test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
+
+		}
+	}
+}
+
+func TestIngressControllerTolerations(t *testing.T) {
+	tests := []ingressControllerTestSuites{
+		{
+			testID:     "toleration-test-create-1",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			operation:  admissionv1.Create,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: false,
+		},
+		{
+			testID:     "toleration-test-create-2",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "admin",
+			userGroups: []string{"system:authenticated", "cluster-admins"},
+			operation:  admissionv1.Create,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: false,
+		},
+		{
+			testID:     "toleration-test-create-3",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "admin",
+			userGroups: []string{"system:authenticated", "cluster-admins"},
+			operation:  admissionv1.Create,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations:     []corev1.Toleration{},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:     "toleration-test-update-1",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "admin",
+			userGroups: []string{"system:authenticated", "dedicated-admin"},
+			operation:  admissionv1.Update,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: false,
+		},
+		{
+			testID:     "toleration-test-update-2",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "admin",
+			userGroups: []string{"system:authenticated", "cluster-admins"},
+			operation:  admissionv1.Update,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: false,
+		},
+		{
+			testID:     "toleration-test-update-3",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "admin",
+			userGroups: []string{"system:authenticated", "cluster-admins"},
+			operation:  admissionv1.Update,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations:     []corev1.Toleration{},
+			shouldBeAllowed: true,
+		},
+	}
+	runIngressControllerTests(t, tests)
+}
+
+func TestIngressControllerExceptions(t *testing.T) {
+	tests := []ingressControllerTestSuites{
+		{
+			testID:     "exception-test-create-serviceaccounts",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "system:serviceaccount:openshift-ingress-operator",
+			userGroups: []string{"system:serviceaccounts:openshift-ingress-operator"},
+			operation:  admissionv1.Create,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:     "exception-test-update-serviceaccounts",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "system:serviceaccount:openshift-ingress-operator",
+			userGroups: []string{"system:serviceaccounts:openshift-ingress-operator"},
+			operation:  admissionv1.Update,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:     "exception-test-create-backplane-cluster-admin",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "backplane-cluster-admin",
+			userGroups: []string{},
+			operation:  admissionv1.Create,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:     "exception-test-update-backplane-cluster-admin",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "backplane-cluster-admin",
+			userGroups: []string{},
+			operation:  admissionv1.Update,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:     "exception-test-create-hive",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "system:serviceaccount:hive:hive-controllers",
+			userGroups: []string{"system;serviceaccounts", "system:serviceaccounts:hive", "system:authenticated"},
+			operation:  admissionv1.Create,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:     "exception-test-update-hive",
+			name:       "shiny-newingress",
+			namespace:  "openshift-ingress-operator",
+			username:   "system:serviceaccount:hive:hive-controllers",
+			userGroups: []string{"system;serviceaccounts", "system:serviceaccounts:hive", "system:authenticated"},
+			operation:  admissionv1.Update,
+			nodeSelector: corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
+			},
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/infra",
+					Operator: "Exists",
+					Effect:   "NoSchedule",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+	}
+	runIngressControllerTests(t, tests)
+}


### PR DESCRIPTION
This resolves [OSD-17439](https://issues.redhat.com//browse/OSD-17439)

The ingress controller webhook blocks non system, non authenticated users from provisioning ingress controllers on master and infra nodes.

A successful creation
```
I0712 13:15:24.454656       1 ingresscontroller.go:115] ingresscontroller-validation "msg"="Checking if user is unauthenticated" 
I0712 13:15:24.454670       1 ingresscontroller.go:125] ingresscontroller-validation "msg"="Checking if user is authenticated system: user" 
```

A blocked creation
```
I0712 13:11:55.259874       1 ingresscontroller.go:115] ingresscontroller-validation "msg"="Checking if user is unauthenticated" 
I0712 13:11:55.259890       1 ingresscontroller.go:125] ingresscontroller-validation "msg"="Checking if user is authenticated system: user" 
I0712 13:11:55.259900       1 ingresscontroller.go:132] ingresscontroller-validation "msg"="Checking if user is kube: user" 
I0712 13:11:55.259909       1 ingresscontroller.go:159] ingresscontroller-validation "msg"="Checking username taislam on whitelist" 
I0712 13:11:55.259919       1 ingresscontroller.go:165] ingresscontroller-validation "msg"="No allowed user found" 
```