### PR TITLE
OSD-16225: Allow kube and system users to delete cluster role bindings

### DIFF
--- a/pkg/webhooks/clusterrolebinding/clusterrolebinding_test.go
+++ b/pkg/webhooks/clusterrolebinding/clusterrolebinding_test.go
@@ -191,6 +191,36 @@ func TestClusterRoleBindingDeletionPositive(t *testing.T) {
 				},
 			},
 		},
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "elevated-sre-can-delete-cluster-role-binding-in-protected-ns",
+			username:                 "backplane-cluster-admin",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated", "system:authenticated:oauth"},
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "openshift-operators",
+				},
+			},
+			shouldBeAllowed: true,
+		},
+		{
+			targetClusterRoleBinding: "whatever",
+			testID:                   "kube-account-can-delete-cluster-role-binding-in-protected-ns",
+			username:                 "kube:admin",
+			operation:                admissionv1.Delete,
+			userGroups:               []string{"system:authenticated"},
+			subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "whatever",
+					Namespace: "openshift-operators",
+				},
+			},
+			shouldBeAllowed: true,
+		},
 	}
 	runClusterRoleBindingTests(t, tests)
 }


### PR DESCRIPTION
**Type**
Bug 

**Why ?**
SREP users and kube admin can't delete cluster role bindings in `openshift-*|kube-system` ns


