### PR TITLE
OSD-18242 block customer modifying ingress config

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ At this point, we have:
 * regular-user-validation-osd
 * scc-validation
 * techpreviewnoupgrade-validation
+* ingress-config-validation
 
 In the [Makefile](/Makefile), the `SELECTOR_SYNC_SET_HOOK_EXCLUDES` variable is used to control which are excluded. By default, it is set to `debug-hook`, in case one should come to appear at some time in the future.
 

--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -243,6 +243,38 @@ objects:
         annotations:
           service.beta.openshift.io/inject-cabundle: "true"
         creationTimestamp: null
+        name: sre-ingress-config-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /ingressconfig-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: ingress-config-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - config.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+          resources:
+          - ingresses
+          scope: Cluster
+        sideEffects: None
+        timeoutSeconds: 2
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        creationTimestamp: null
         name: sre-namespace-validation
       webhooks:
       - admissionReviewVersions:

--- a/pkg/webhooks/add_ingressconfig_hook.go
+++ b/pkg/webhooks/add_ingressconfig_hook.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/ingressconfig"
+)
+
+func init() {
+	Register(ingressconfig.WebhookName, func() Webhook { return ingressconfig.NewWebhook() })
+}

--- a/pkg/webhooks/ingressconfig/ingressconfig.go
+++ b/pkg/webhooks/ingressconfig/ingressconfig.go
@@ -1,0 +1,136 @@
+package ingressconfig
+
+import (
+	"os"
+	"regexp"
+	"sync"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+)
+
+const (
+	WebhookName               string = "ingress-config-validation"
+	privilegedServiceAccounts string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*|osde2e-[a-z0-9]{5})`
+	docString                 string = `Managed OpenShift customers may not modify ingress config resources because it can can degrade cluster operators and can interfere with OpenShift SRE monitoring.`
+)
+
+var (
+	log                         = logf.Log.WithName(WebhookName)
+	privilegedServiceAccountsRe = regexp.MustCompile(privilegedServiceAccounts)
+
+	scope = admissionregv1.ClusterScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"CREATE", "UPDATE", "DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"config.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"ingresses"},
+				Scope:       &scope,
+			},
+		},
+	}
+)
+
+type IngressConfigWebhook struct {
+	mu sync.Mutex
+	s  runtime.Scheme
+}
+
+// Authorized will determine if the request is allowed
+func (w *IngressConfigWebhook) Authorized(request admissionctl.Request) (ret admissionctl.Response) {
+	// deny unless modified by an allowlist-ed service account
+	for _, group := range request.UserInfo.Groups {
+		if privilegedServiceAccountsRe.Match([]byte(group)) {
+			ret = admissionctl.Allowed("Privileged service accounts may access")
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
+	}
+
+	return
+}
+
+// GetURI returns the URI for the webhook
+func (w *IngressConfigWebhook) GetURI() string { return "/ingressconfig-validation" }
+
+// Validate will validate the incoming request
+func (w *IngressConfigWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "Ingress")
+
+	return valid
+}
+
+// Name is the name of the webhook
+func (w *IngressConfigWebhook) Name() string { return WebhookName }
+
+// FailurePolicy is how the hook config should react if k8s can't access it
+func (w *IngressConfigWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// MatchPolicy mirrors validatingwebhookconfiguration.webhooks[].matchPolicy
+// If it is important to the webhook, be sure to check subResource vs
+// requestSubResource.
+func (w *IngressConfigWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Rules is a slice of rules on which this hook should trigger
+func (w *IngressConfigWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// ObjectSelector uses a *metav1.LabelSelector to augment the webhook's
+// Rules() to match only on incoming requests which match the specific
+// LabelSelector.
+func (w *IngressConfigWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
+// SideEffects are what side effects, if any, this hook has. Refer to
+// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
+func (w *IngressConfigWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// TimeoutSeconds returns an int32 representing how long to wait for this hook to complete
+func (w *IngressConfigWebhook) TimeoutSeconds() int32 { return 2 }
+
+// Doc returns a string for end-customer documentation purposes.
+func (w *IngressConfigWebhook) Doc() string { return docString }
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+// Return utils.DefaultLabelSelector() to stick with the default
+func (w *IngressConfigWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	return utils.DefaultLabelSelector()
+}
+
+// HypershiftEnabled will return boolean value for hypershift enabled configurations
+func (w *IngressConfigWebhook) HypershiftEnabled() bool { return true }
+
+// NewWebhook creates a new webhook
+func NewWebhook() *IngressConfigWebhook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to IngressConfigWebhook")
+		os.Exit(1)
+	}
+
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding corev1 scheme to IngressConfigWebhook")
+		os.Exit(1)
+	}
+
+	return &IngressConfigWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/ingressconfig/ingressconfig.go
+++ b/pkg/webhooks/ingressconfig/ingressconfig.go
@@ -47,12 +47,14 @@ type IngressConfigWebhook struct {
 
 // Authorized will determine if the request is allowed
 func (w *IngressConfigWebhook) Authorized(request admissionctl.Request) (ret admissionctl.Response) {
+	ret = admissionctl.Denied("Only privileged service accounts may access")
+	ret.UID = request.AdmissionRequest.UID
+
 	// deny unless modified by an allowlist-ed service account
 	for _, group := range request.UserInfo.Groups {
 		if privilegedServiceAccountsRe.Match([]byte(group)) {
 			ret = admissionctl.Allowed("Privileged service accounts may access")
 			ret.UID = request.AdmissionRequest.UID
-			return ret
 		}
 	}
 

--- a/pkg/webhooks/ingressconfig/ingressconfig_test.go
+++ b/pkg/webhooks/ingressconfig/ingressconfig_test.go
@@ -1,0 +1,217 @@
+package ingressconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestAuthorized(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Request       admissionctl.Request
+		ExpectAllowed bool
+	}{
+		{
+			Name: "privileged account should be allowed",
+			Request: admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Groups: []string{
+							"system:serviceaccounts:openshift-backplane-srep",
+						},
+					},
+				},
+			},
+			ExpectAllowed: true,
+		},
+		{
+			Name: "non-privileged account should be denied",
+			Request: admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Groups: []string{},
+					},
+				},
+			},
+			ExpectAllowed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			w := NewWebhook()
+			ret := w.Authorized(test.Request)
+
+			if ret.Allowed != test.ExpectAllowed {
+				t.Errorf("TestAuthorized() %s: request %v - allowed: %t, expected: %t\n", test.Name, test.Request, ret.Allowed, test.ExpectAllowed)
+			}
+		})
+	}
+}
+
+func TestGetURI(t *testing.T) {
+	uri := NewWebhook().GetURI()
+
+	if uri != "/ingressconfig-validation" {
+		t.Errorf("TestGetURI(): expected \"/ingressconfig-validation\", got: %s", uri)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Request     admissionctl.Request
+		ExpectValid bool
+	}{
+		{
+			Name: "invalidate requests without a username",
+			Request: admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: "",
+					},
+					Kind: metav1.GroupVersionKind{
+						Kind: "Ingress",
+					},
+				},
+			},
+			ExpectValid: false,
+		},
+		{
+			Name: "invalidate requests without a kind",
+			Request: admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test",
+					},
+				},
+			},
+			ExpectValid: false,
+		},
+		{
+			Name: "validate requests",
+			Request: admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test",
+					},
+					Kind: metav1.GroupVersionKind{
+						Kind: "Ingress",
+					},
+				},
+			},
+			ExpectValid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			w := NewWebhook()
+			valid := w.Validate(test.Request)
+
+			if valid != test.ExpectValid {
+				t.Errorf("TestValidate() %s: expected %t, got %t\n", test.Name, test.ExpectValid, valid)
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	name := NewWebhook().Name()
+
+	if name != "ingress-config-validation" {
+		t.Errorf("Name(): expected \"ingress-config-validation\", got \"%s\"\n", name)
+	}
+}
+
+func TestFailurePolicy(t *testing.T) {
+	policy := NewWebhook().FailurePolicy()
+
+	if policy != admissionregv1.Ignore {
+		t.Errorf("TestFailurePolicy(): expected Ignore, got %s\n", policy)
+	}
+}
+
+func TestMatchPolicy(t *testing.T) {
+	policy := NewWebhook().MatchPolicy()
+
+	if policy != admissionregv1.Equivalent {
+		t.Errorf("TestFailurePolicy(): expected Equivalent, got %s\n", policy)
+	}
+}
+
+func TestRules(t *testing.T) {
+	scope := admissionregv1.ClusterScope
+	expectedRules := []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"CREATE", "UPDATE", "DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"config.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"ingresses"},
+				Scope:       &scope,
+			},
+		},
+	}
+
+	rules := NewWebhook().Rules()
+
+	if !reflect.DeepEqual(expectedRules, rules) {
+		t.Errorf("TestRules(): expected %v, got %v\n", expectedRules, rules)
+	}
+}
+
+func TestObjectSelector(t *testing.T) {
+	labelSelector := NewWebhook().ObjectSelector()
+
+	if labelSelector != nil {
+		t.Errorf("TestObjectSelector(): expected nil, got %v\n", labelSelector)
+	}
+}
+
+func TestSideEffects(t *testing.T) {
+	sideEffects := NewWebhook().SideEffects()
+
+	if sideEffects != admissionregv1.SideEffectClassNone {
+		t.Errorf("TestSideEffects(): expected %v, got %v\n", admissionregv1.SideEffectClassNone, sideEffects)
+	}
+}
+
+func TestTimeoutSeconds(t *testing.T) {
+	timeout := NewWebhook().TimeoutSeconds()
+
+	if timeout != 2 {
+		t.Errorf("TestTimeoutSeconds(): expected 2, got %d\n", timeout)
+	}
+}
+
+func TestDoc(t *testing.T) {
+	docs := NewWebhook().Doc()
+
+	if len(docs) == 0 {
+		t.Error("TestDoc(): expected content, recieved none")
+	}
+}
+
+func TestSyncSetLabelSelector(t *testing.T) {
+	labelSelector := NewWebhook().SyncSetLabelSelector()
+
+	if !reflect.DeepEqual(labelSelector, utils.DefaultLabelSelector()) {
+		t.Errorf("TestSyncSetLabelSelector(): expected %v, got %v\n", utils.DefaultLabelSelector(), labelSelector)
+	}
+}
+
+func TestHypershiftEnabled(t *testing.T) {
+	enabled := NewWebhook().HypershiftEnabled()
+
+	if !enabled {
+		t.Error("TestHypershiftEnabled(): expected enabled")
+	}
+}


### PR DESCRIPTION
This webhook will prevent non-privileged serviceaccounts from creating, updating or deleting ingresses from config.openshift.io

Modifications to the cluster ingress config can degrade the authentication, console, and ingress operators