### PR TITLE
Buid packages with PKO CLI

### DIFF
--- a/build/pr_check.sh
+++ b/build/pr_check.sh
@@ -7,8 +7,8 @@ echo "Using go version $(go version)"
 
 CURRENT_DIR=$(dirname "$0")
 
-#BUILD_CMD="build-base" make lint test build-sss build-base
-make -C $(dirname $0)/../ container-test syncset package build-base
+#BUILD_CMD="build-base" make lint test build-sss validate-build
+make -C $(dirname $0)/../ container-test syncset package validate-build
 
 # make sure nothing changed (i.e. SSS templates being invalid)
 git diff --exit-code

--- a/build/pr_check.sh
+++ b/build/pr_check.sh
@@ -7,8 +7,8 @@ echo "Using go version $(go version)"
 
 CURRENT_DIR=$(dirname "$0")
 
-#BUILD_CMD="build-base" make lint test build-sss validate-build
-make -C $(dirname $0)/../ container-test syncset package validate-build
+#BUILD_CMD="build-base" make lint test build-sss build-base validate-build
+make -C $(dirname $0)/../ container-test syncset package build-base validate-build
 
 # make sure nothing changed (i.e. SSS templates being invalid)
 git diff --exit-code

--- a/config/package/.gitignore
+++ b/config/package/.gitignore
@@ -1,0 +1,2 @@
+/manifest.lock.yaml
+/validating-webhooks-package.oci

--- a/config/package/.test-fixtures/default/resources.yaml
+++ b/config/package/.test-fixtures/default/resources.yaml
@@ -69,14 +69,14 @@ spec:
               - key: hypershift.openshift.io/cluster
                 operator: In
                 values:
-                - '{{.package.metadata.namespace}}'
+                - 'ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3'
             weight: 100
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  hypershift.openshift.io/hosted-control-plane: '{{.package.metadata.namespace}}'
+                  hypershift.openshift.io/hosted-control-plane: 'ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3'
               topologyKey: kubernetes.io/hostname
             weight: 100
         podAntiAffinity:
@@ -96,7 +96,7 @@ spec:
         - -cacert
         - /service-ca/service-ca.crt
         - -tls
-        image: {{ index .images "validating-webhooks-server" }}
+        image: registry.package-operator.run/static-image
         imagePullPolicy: IfNotPresent
         name: webhooks
         ports:
@@ -122,7 +122,7 @@ spec:
       - effect: NoSchedule
         key: hypershift.openshift.io/cluster
         operator: Equal
-        value: '{{.package.metadata.namespace}}'
+        value: 'ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3'
       volumes:
       - name: service-certs
         secret:
@@ -144,8 +144,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/clusterrolebindings-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/clusterrolebindings-validation
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: clusterrolebindings-validation.managed.openshift.io
@@ -174,8 +174,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/imagecontentpolicies-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/imagecontentpolicies-validation
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: imagecontentpolicies-validation.managed.openshift.io
@@ -216,8 +216,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/namespace-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/namespace-validation
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: namespace-validation.managed.openshift.io
@@ -248,8 +248,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/regularuser-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/regularuser-validation
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: regular-user-validation.managed.openshift.io
@@ -360,8 +360,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/scc-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/scc-validation
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: scc-validation.managed.openshift.io
@@ -391,8 +391,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/serviceaccount-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/serviceaccount-validation
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: serviceaccount-validation.managed.openshift.io
@@ -421,8 +421,8 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/techpreviewnoupgrade-validation
+    caBundle: 'SSBvd2UgeW91IGEgc2VydmljZSBDQSAucGVt'
+    url: https://validation-webhook.ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3.svc.cluster.local/techpreviewnoupgrade-validation
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: techpreviewnoupgrade-validation.managed.openshift.io

--- a/config/package/managed-cluster-validating-webhooks-package.Containerfile
+++ b/config/package/managed-cluster-validating-webhooks-package.Containerfile
@@ -1,3 +1,0 @@
-FROM scratch
-
-ADD config/package/*.yaml* /package/

--- a/config/package/manifest.yaml
+++ b/config/package/manifest.yaml
@@ -32,3 +32,18 @@ spec:
         kind:
           group: apps
           kind: Deployment
+  images:
+  - name: validating-webhooks-server
+    image: REPLACED_BY_PIPELINE
+test:
+  kubeconform:
+    kubernetesVersion: v1.28.2
+  template:
+  - name: default
+    context:
+      package:
+        metadata:
+          name: validating-webhooks
+          namespace: ocm-staging-27856078sqvcknaeamh6hunqmu6eorv3-linnguye-hcp-3
+      config:
+        serviceca: I owe you a service CA .pem


### PR DESCRIPTION
Use Package Operator CLI to build the package image.
Using the CLI will validate:
- all PKO manifests
- kubernetes schemas
- template output matches fixtures
- object labels are valid

It will also automatically expand image tags into digests at build-time to ensure immutability.
The used image is build on RH internal infrastructure for supply-chain-security and is FIPS enabled.

---
To check it out yourself:
```
# Add a mistake to resources.yaml.gotmpl e.g.:
# spec:
#   affxxxinity:
$ make validate-package-image

Error: validating package: loading package from files: Kubeconform rejected schema in resources.yaml idx 2: problem validating schema. Check JSON formatting: jsonschema: '/spec/template/spec' does not validate with https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.28.2-standalone-strict/deployment-apps-v1.json#/properties/spec/properties/template/properties/spec/additionalProperties: additionalProperties 'affxxxinity' not allowed
File mismatch against fixture in resources.yaml.gotmpl: Testcase "default"
--- FIXTURE/resources.yaml
+++ ACTUAL/resources.yaml
@@ -54,7 +54,7 @@
       labels:
         app: validation-webhook
     spec:
-      affinity:
+      affxxxinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
```
You should get both a kubeconform error `additionalProperties 'affxxxinity' not allowed` and an error against the test fixture.