### PR TITLE
change the log for prometheus webhook less verbose

### DIFF
--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -104,7 +104,7 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 		return ret
 	}
 
-	log.Info("Allowing access", "request", request.AdmissionRequest)
+	log.Info("Allowing access")
 	ret = admissionctl.Allowed("Non managed namespace")
 	ret.UID = request.AdmissionRequest.UID
 	return ret


### PR DESCRIPTION
The request body will be pretty large for the prometheus rule resource. Remove the request body from the log.