### PR TITLE
removes selinux label setting for make container-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ $(PACKAGE_RESOURCE_DESTINATION):
 .PHONY: container-test
 container-test:
 	$(CONTAINER_ENGINE) run \
-		-v $(CURDIR):$(CURDIR):z \
+		-v $(CURDIR):$(CURDIR) \
 		-w $(CURDIR) \
 		-e GOFLAGS=$(GOFLAGS) \
 		--rm \


### PR DESCRIPTION
fixes error: lsetxattr when running make container-test

```
[tomas@ugnis-ocm managed-cluster-validating-webhooks]$ make container-test
/usr/bin/podman run \
	-v /volumes/development/ugnis/src/github/openshift/managed-cluster-validating-webhooks:/volumes/development/ugnis/src/github/openshift/managed-cluster-validating-webhooks:z \
	-w /volumes/development/ugnis/src/github/openshift/managed-cluster-validating-webhooks \
	-e GOFLAGS= \
	--rm \
	registry.ci.openshift.org/openshift/release:golang-1.21 \
		make test
Error: lsetxattr /volumes/development/ugnis/src/github/openshift/managed-cluster-validating-webhooks/.git: operation not supported
make: *** [Makefile:140: container-test] Error 126
```