### PR TITLE
Update regex to allow osde2e harness serviceaccount to be exempt

### DIFF
--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -22,7 +22,6 @@ import (
 const (
 	WebhookName                  string = "namespace-validation"
 	badNamespace                 string = `(^com$|^io$|^in$)`
-	privilegedServiceAccounts    string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*|osde2e-[a-z0-9]{5})`
 	layeredProductNamespace      string = `^redhat.*`
 	layeredProductAdminGroupName string = "layered-sre-cluster-admins"
 	docString                    string = `Managed OpenShift Customers may not modify namespaces specified in the %v ConfigMaps because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression %s because it could interfere with critical DNS resolution. Additionally, customers may not set or change the values of these Namespace labels %s.`
@@ -37,7 +36,7 @@ var (
 var (
 	clusterAdminUsers           = []string{"kube:admin", "system:admin", "backplane-cluster-admin"}
 	sreAdminGroups              = []string{"system:serviceaccounts:openshift-backplane-srep"}
-	privilegedServiceAccountsRe = regexp.MustCompile(privilegedServiceAccounts)
+	privilegedServiceAccountsRe = regexp.MustCompile(utils.PrivilegedServiceAccountGroups)
 	layeredProductNamespaceRe   = regexp.MustCompile(layeredProductNamespace)
 	// protectedLabels are labels which managed customers should not be allowed
 	// change by dedicated-admins.

--- a/pkg/webhooks/networkpolicies/networkpolicies.go
+++ b/pkg/webhooks/networkpolicies/networkpolicies.go
@@ -18,16 +18,15 @@ import (
 )
 
 const (
-	WebhookName                    string = "networkpolicies-validation"
-	docString                      string = `Managed OpenShift Customers may not create NetworkPolicies in namespaces managed by Red Hat.`
-	privilegedServiceAccountGroups string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*|osde2e-[a-z0-9]{5})`
+	WebhookName string = "networkpolicies-validation"
+	docString   string = `Managed OpenShift Customers may not create NetworkPolicies in namespaces managed by Red Hat.`
 )
 
 var (
 	timeout                          int32 = 2
 	allowedUsers                           = []string{"system:admin", "backplane-cluster-admin"}
 	sreAdminGroups                         = []string{"system:serviceaccounts:openshift-backplane-srep"}
-	privilegedServiceAccountGroupsRe       = regexp.MustCompile(privilegedServiceAccountGroups)
+	privilegedServiceAccountGroupsRe       = regexp.MustCompile(utils.PrivilegedServiceAccountGroups)
 	scope                                  = admissionregv1.NamespacedScope
 	rules                                  = []admissionregv1.RuleWithOperations{
 		{

--- a/pkg/webhooks/networkpolicies/networkpolicies_test.go
+++ b/pkg/webhooks/networkpolicies/networkpolicies_test.go
@@ -80,6 +80,15 @@ func runNetworkPolicyTests(t *testing.T, tests []networkPolicyTestSuites) {
 func TestUsers(t *testing.T) {
 	tests := []networkPolicyTestSuites{
 		{
+			// osde2e-related things can delete a networkpolicy
+			testID:          "osde2e-oao-delete-networkpolicy",
+			targetNamespace: "openshift-ocm-agent-operator",
+			username:        "system:serviceaccount:osde2e-h-9a47q:cluster-admin",
+			userGroups:      []string{"system:serviceaccounts:osde2e-h-9a47q", "system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Delete,
+			shouldBeAllowed: true,
+		},
+		{
 			testID:          "regular-user-cant-create-networkpolicy-in-managed-namespaces",
 			targetNamespace: "openshift-kube-apiserver",
 			targetResource:  "networkpolicy",

--- a/pkg/webhooks/utils/utils.go
+++ b/pkg/webhooks/utils/utils.go
@@ -15,7 +15,14 @@ import (
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-const validContentType string = "application/json"
+const (
+	validContentType string = "application/json"
+	// PrivilegedServiceAccountGroups is a regex string of serviceaccounts that our webhooks should commonly allow to
+	// perform restricted actions.
+	// Centralized osde2e tests have a serviceaccount like "system:serviceaccounts:osde2e-abcde"
+	// Decentralized osde2e tests have a serviceaccount like "system:serviceaccounts:osde2e-h-abcde"
+	PrivilegedServiceAccountGroups string = `^system:serviceaccounts:(kube.*|openshift.*|default|redhat.*|osde2e-(h-)?[a-z0-9]{5})`
+)
 
 var (
 	admissionScheme = runtime.NewScheme()


### PR DESCRIPTION
The regex was used in two places, so I centralized it within utils.go as well. I essentially added a `(h-)?` to the existing regex. This has been causing the osde2e test for OAO to consistently fail https://testgrid.k8s.io/redhat-openshift-ocp-release-4.14-informing#periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts 

Ref for why we need the optional `h-` (i.e. all decentralized osde2e tests will have this extra `h-` in the name): https://github.com/openshift/osde2e/blob/8202c6aae11848874aee554f733df5f44468e8f1/pkg/e2e/harness_runner/harness_runner.go#L52-L54

[OSD-20366](https://issues.redhat.com//browse/OSD-20366)