### PR TITLE
Networkpolicies: Fix UPDATE requests

### DIFF
--- a/pkg/webhooks/networkpolicies/networkpolicies.go
+++ b/pkg/webhooks/networkpolicies/networkpolicies.go
@@ -137,15 +137,12 @@ func (s *networkpoliciesruleWebhook) renderNetworkPolicy(req admissionctl.Reques
 	}
 	networkPolicy := &networkingv1.NetworkPolicy{}
 
-	if len(req.OldObject.Raw) > 0 {
-		err = decoder.DecodeRaw(req.OldObject, networkPolicy)
-	} else {
-		err = decoder.Decode(req, networkPolicy)
+	if len(req.Object.Raw) > 0 {
+		err = decoder.DecodeRaw(req.Object, networkPolicy)
+		return networkPolicy, err
 	}
-	if err != nil {
-		return nil, err
-	}
-	return networkPolicy, nil
+	err = decoder.DecodeRaw(req.OldObject, networkPolicy)
+	return networkPolicy, err
 }
 
 // GetURI implements Webhook interface


### PR DESCRIPTION
* UPDATE requests validated the OldObjects of the request
* OldObject is only used for update and delete requests, so when a new object exists it's always that which should be validated

Jira: [OSD-20308](https://issues.redhat.com//browse/OSD-20308)