### PR TITLE
Remove ServiceAccount from packaged deployment

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -326,8 +326,6 @@ func createPackagedDeployment(replicas int32, phase string) *appsv1.Deployment {
 					},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:           serviceAccountName,
-					AutomountServiceAccountToken: &[]bool{true}[0],
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -85,7 +85,6 @@ spec:
               matchLabels:
                 app: validation-webhook
             topologyKey: topology.kubernetes.io/zone
-      automountServiceAccountToken: true
       containers:
       - command:
         - webhooks
@@ -110,7 +109,6 @@ spec:
           name: service-ca
           readOnly: true
       restartPolicy: Always
-      serviceAccountName: validation-webhook
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane


### PR DESCRIPTION
This PR addresses bug [OSD-20871](https://issues.redhat.com/browse/OSD-20871), in which MCVW's HCP package failed to deploy on management clusters due to an extraneous reference to a service account. None of our HyperShift-enabled webhooks need access to the cluster's API, so this PR removes that reference.