### PR TITLE
Make failure-to-start-metrics non-fatal

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 	for name, hook := range webhooks.Webhooks {
 		realHook := hook()
 		if seen[realHook.GetURI()] {
-			panic(fmt.Errorf("Duplicate webhook trying to lisen on %s", realHook.GetURI()))
+			panic(fmt.Errorf("Duplicate webhook trying to listen on %s", realHook.GetURI()))
 		}
 		seen[name] = true
 		if !*testHooks {
@@ -85,9 +85,9 @@ func main() {
 	} else {
 		if err := metrics.ConfigureMetrics(context.TODO(), *metricsServer); err != nil {
 			log.Error(err, "Failed to configure metrics")
-			os.Exit(1)
+		} else {
+			log.Info("Successfully configured metrics")
 		}
-		log.Info("Successfully configured metrics")
 	}
 
 	server := &http.Server{


### PR DESCRIPTION
This PR addresses bug [OSD-20871](https://issues.redhat.com/browse/OSD-20871) (also addressed by #284), in which MCVW's HCP package is failing to deploy on management clusters due to a failure to start the new metrics server. This failure occurs because the metrics server attempts to create a Service via the K8s API, but the default service account in use by the HCP package lacks permissions to do so. A future PR could introduce this Service by adding a resource to the generated package, but for now (in the interest of getting webhooks on HCP working again), this PR simply makes the failure-to-start-metrics error non-fatal (as there's no readiness/health check on HCP that would be making requests to the metrics Service anyways).