### PR TITLE
Allow osde2e to modify SCCs

### DIFF
--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -167,6 +167,14 @@ func TestUserPositive(t *testing.T) {
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
 			shouldBeAllowed: true,
 		},
+		{
+			targetSCC:       "privileged",
+			testID:          "osde2e-serviceaccounts-are-allowed",
+			username:        "system:serviceaccount:osde2e-abcde:osde2e-runner",
+			operation:       admissionv1.Update,
+			userGroups:      []string{"system:authenticated", "system:serviceaccounts:osde2e-abcde"},
+			shouldBeAllowed: true,
+		},
 	}
 	runSCCTests(t, tests)
 }


### PR DESCRIPTION
osde2e runs a conformance test which needs to be able to modify SCCs https://github.com/openshift/kubernetes/blob/e994e5dbd69833088514616351b0aa997e4ed79d/openshift-hack/e2e/namespace.go#L64-L71

This PR accomplishes this by adding a regexp for the osde2e group as a privileged group that can modify SCCs at will.

[OSD-22059](https://issues.redhat.com/browse/OSD-22059)