### PR TITLE
Revert "Block changes to imageregistry.operator.openshift.io resources"

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -571,7 +571,6 @@ objects:
           - cloudcredential.openshift.io
           - machine.openshift.io
           - admissionregistration.k8s.io
-          - imageregistry.operator.openshift.io
           - addons.managed.openshift.io
           - cloudingress.managed.openshift.io
           - managed.openshift.io

--- a/pkg/webhooks/regularuser/common/regularuser.go
+++ b/pkg/webhooks/regularuser/common/regularuser.go
@@ -57,7 +57,6 @@ var (
 					"cloudcredential.openshift.io",
 					"machine.openshift.io",
 					"admissionregistration.k8s.io",
-					"imageregistry.operator.openshift.io",
 					// Deny ability to manage SRE resources
 					// oc get --raw /apis | jq -r '.groups[] | select(.name | contains("managed")) | .name'
 					"addons.managed.openshift.io",


### PR DESCRIPTION
This reverts commit 86f079d436973b8781157c1bd4e65d316845daa3, reversing changes made to 58448970c2f94cd0fd546ca349f7ee13f99ef3d4.

ref [OSD-22474](https://issues.redhat.com//browse/OSD-22474)