### PR TITLE
Fix improper rendering of Services in service-mutation webhook

### DIFF
--- a/pkg/webhooks/service/service.go
+++ b/pkg/webhooks/service/service.go
@@ -151,11 +151,7 @@ func (s *ServiceWebhook) renderService(req admissionctl.Request) (*corev1.Servic
 	}
 	service := &corev1.Service{}
 
-	if len(req.OldObject.Raw) > 0 {
-		err = decoder.DecodeRaw(req.OldObject, service)
-	} else {
-		err = decoder.Decode(req, service)
-	}
+	err = decoder.Decode(req, service)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR addresses bug [OSD-21590](https://issues.redhat.com/browse/OSD-21590), in which the service-mutation webhook would sometimes allow users to modify or remove the `red-hat-managed=true` resource tag that's required for AWS managed policy compliance. This bug was caused by improper use of [AdmissionRequest.OldObject](https://pkg.go.dev/k8s.io/api/admission/v1#AdmissionRequest) within the mutating webhook's "object rendering" function `renderService()`. 

This PR fixes the bug by ignoring AdmissionRequest.OldObject entirely and always rendering AdmissionRequest.Object. It also adds unit tests that will catch any regressions on the bug.