### PR TITLE
Updated podimagespec to support HCP

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -465,6 +465,14 @@ func createPackagedDeployment(replicas int32, phase string) *appsv1.Deployment {
 								},
 							},
 						},
+						{
+							Name: "hosted-kubeconfig",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "service-network-admin-kubeconfig",
+								},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -484,6 +492,11 @@ func createPackagedDeployment(replicas int32, phase string) *appsv1.Deployment {
 									MountPath: "/service-ca",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "hosted-kubeconfig",
+									MountPath: "/etc/hosted-kubernetes",
+									ReadOnly:  true,
+								},
 							},
 							Ports: []corev1.ContainerPort{
 								{
@@ -496,6 +509,12 @@ func createPackagedDeployment(replicas int32, phase string) *appsv1.Deployment {
 								"-tlscert", "/service-certs/tls.crt",
 								"-cacert", "/service-ca/service-ca.crt",
 								"-tls",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "KUBECONFIG",
+									Value: "/etc/hosted-kubernetes/kubeconfig",
+								},
 							},
 						},
 					},

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -96,6 +96,9 @@ spec:
         - -cacert
         - /service-ca/service-ca.crt
         - -tls
+        env:
+        - name: KUBECONFIG
+          value: /etc/hosted-kubernetes/kubeconfig
         image: REPLACED_BY_PIPELINE
         imagePullPolicy: IfNotPresent
         name: webhooks
@@ -108,6 +111,9 @@ spec:
           readOnly: true
         - mountPath: /service-ca
           name: service-ca
+          readOnly: true
+        - mountPath: /etc/hosted-kubernetes
+          name: hosted-kubeconfig
           readOnly: true
       restartPolicy: Always
       tolerations:
@@ -130,6 +136,9 @@ spec:
       - configMap:
           name: webhook-cert
         name: service-ca
+      - name: hosted-kubeconfig
+        secret:
+          secretName: service-network-admin-kubeconfig
 status: {}
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -66,9 +66,10 @@ func (d *Dispatcher) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		// Valid AdmissionReview, but we can't do anything with it because we do not
 		// think the request inside is valid.
 		if !hook().Validate(request) {
+			err = fmt.Errorf("not a valid webhook request")
+			log.Error(err, "Error validaing HTTP Request Body")
 			responsehelper.SendResponse(w,
-				admissionctl.Errored(http.StatusBadRequest,
-					fmt.Errorf("Not a valid webhook request")))
+				admissionctl.Errored(http.StatusBadRequest, err))
 			return
 		}
 
@@ -83,5 +84,5 @@ func (d *Dispatcher) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(404)
 	responsehelper.SendResponse(w,
 		admissionctl.Errored(http.StatusBadRequest,
-			fmt.Errorf("Request is not for a registered webhook")))
+			fmt.Errorf("request is not for a registered webhook")))
 }


### PR DESCRIPTION
Requires getting kubeconfig to the KAS for the HCP, not the cluster where the webbhook pod is running.