### PR TITLE
OSD-23318: Allow to modify IDMS in hosted clusters 

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -133,6 +133,17 @@ func createRole() *rbacv1.Role {
 					"*",
 				},
 			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"configmaps",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
 		},
 	}
 }

--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -53,6 +53,12 @@ objects:
         - servicemonitors
         verbs:
         - '*'
+      - apiGroups:
+        - ""
+        resources:
+        - configmaps
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:


### PR DESCRIPTION
## What 
As part of zero-egress implementation, hosted clusters IDMS needs to update with private ECR 

- This PR allows mirroring ECR's  for hosted clusters via the feature flag
- backplane service account allows to update IDMS/ICSP/ITMS

## JIRA 
https://issues.redhat.com/browse/OSD-23318