### PR TITLE
Fix a harmless typo preventing clusterversion restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ serve:
 
 .PHONY: vet
 vet:
-	$(AT)gofmt -s -l $(shell go list -f '{{ .Dir }}' ./... ) | grep ".*\.go"; if [ "$$?" = "0" ]; then gofmt -s -d $(shell go list -f '{{ .Dir }}' ./... ); exit 1; fi
+	$(AT)go fmt ./...
 	$(AT)go vet ./cmd/... ./pkg/...
 
 .PHONY: generate
@@ -138,7 +138,7 @@ $(PACKAGE_RESOURCE_DESTINATION):
 .PHONY: container-test
 container-test:
 	$(CONTAINER_ENGINE) run \
-		-v $(CURDIR):$(CURDIR) \
+		-v $(CURDIR):$(CURDIR):z \
 		-w $(CURDIR) \
 		-e GOFLAGS=$(GOFLAGS) \
 		--rm \

--- a/pkg/webhooks/regularuser/common/regularuser.go
+++ b/pkg/webhooks/regularuser/common/regularuser.go
@@ -32,7 +32,7 @@ const (
 	mustGatherKind      = "MustGather"
 	mustGatherGroup     = "managed.openshift.io"
 	clusterVersionKind  = "ClusterVersion"
-	clusterVersionGroup = "config.openshit.io"
+	clusterVersionGroup = "config.openshift.io"
 	customDomainKind    = "CustomDomain"
 	customDomainGroup   = "managed.openshift.io"
 	netNamespaceKind    = "NetNamespace"


### PR DESCRIPTION
* CI was failing because it was recently switched from docker to podman, this PR also fixes the root of the CI failures by SELinux relabling the volume mount when running `make container-test`

[OSD-24357](https://issues.redhat.com//browse/OSD-24357)