### PR TITLE
Fix MCVW builds on RHEL8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,36 +146,27 @@ container-test:
 			make test
 
 ### Imported
-.PHONY: skopeo-push
-skopeo-push:
+.PHONY: container-image-push 
+container-image-push:
 	@if [[ -z $$QUAY_USER || -z $$QUAY_TOKEN ]]; then \
 		echo "You must set QUAY_USER and QUAY_TOKEN environment variables" ;\
 		echo "ex: make QUAY_USER=value QUAY_TOKEN=value $@" ;\
 		exit 1 ;\
 	fi
-	# QUAY_USER and QUAY_TOKEN are supplied as env vars
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${IMG}:${IMAGETAG}" \
-		"docker://${IMG}:latest"
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${IMG}:${IMAGETAG}" \
-		"docker://${IMG}:${IMAGETAG}"
+	$(CONTAINER_ENGINE) login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+	$(CONTAINER_ENGINE) push "${IMG}:${IMAGETAG}"
+	$(CONTAINER_ENGINE) push "${IMG}:latest"
 
-.PHONY: skopeo-push-package
-skopeo-push-package:
+.PHONY: package-push
+package-push:
 	@if [[ -z $$QUAY_USER || -z $$QUAY_TOKEN ]]; then \
 		echo "You must set QUAY_USER and QUAY_TOKEN environment variables" ;\
 		echo "ex: make QUAY_USER=value QUAY_TOKEN=value $@" ;\
 		exit 1 ;\
 	fi
-	# QUAY_USER and QUAY_TOKEN are supplied as env vars
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${PKG_IMG}:${IMAGETAG}" \
-		"docker://${PKG_IMG}:latest"
-	skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-		"docker-daemon:${PKG_IMG}:${IMAGETAG}" \
-		"docker://${PKG_IMG}:${IMAGETAG}"
-
+	$(CONTAINER_ENGINE) login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+	$(CONTAINER_ENGINE) push "${PKG_IMG}:${IMAGETAG}"
+	$(CONTAINER_ENGINE) push "${PKG_IMG}:latest"
 
 .PHONY: push-base
 push-base: build/Dockerfile

--- a/build/build_push.sh
+++ b/build/build_push.sh
@@ -90,4 +90,4 @@ if image_exists_in_repo "$IMAGE_URI"; then
 fi
 
 # build the image, the selectorsyncset, and push the image
-make -C $(dirname $0)/../ syncset build-base skopeo-push
+make -C $(dirname $0)/../ syncset build-base container-image-push

--- a/build/build_push_package.sh
+++ b/build/build_push_package.sh
@@ -90,4 +90,4 @@ if image_exists_in_repo "$IMAGE_URI"; then
 fi
 
 # build the image, the selectorsyncset, and push the image
-make -C $(dirname $0)/../ package build-base skopeo-push-package
+make -C $(dirname $0)/../ package build-base package-push


### PR DESCRIPTION
* With the switch from docker to podman, just use podman to push instead of using skopeo to copy images from the docker socket

The last build failed https://ci.int.devshift.net/job/openshift-managed-cluster-validating-webhooks-gh-build-master/305/console:

```
# QUAY_USER and QUAY_TOKEN are supplied as env vars
11:02:51 skopeo copy --dest-creds "****:****" \
11:02:51 	"docker-daemon:quay.io/app-sre/managed-cluster-validating-webhooks:24539be" \
11:02:51 	"docker://quay.io/app-sre/managed-cluster-validating-webhooks:latest"
11:02:51 time="2024-07-09T15:02:51Z" level=fatal msg="initializing source docker-daemon:quay.io/app-sre/managed-cluster-validating-webhooks:24539be: loading image from docker engine: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get \"http://%2Fvar%2Frun%2Fdocker.sock/v1.24/images/get?names=quay.io%2Fapp-sre%2Fmanaged-cluster-validating-webhooks%3A24539be\": dial unix /var/run/docker.sock: connect: permission denied"
```

This PR fixes the issue in a similar manner to https://github.com/openshift/boilerplate/pull/370

[OSD-24357](https://issues.redhat.com//browse/OSD-24357)