### PR TITLE
OSD-24266 : Disabled IDMS/ICSP validatingwebhook in HCP

### DIFF
--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -178,48 +178,6 @@ metadata:
     package-operator.run/phase: webhooks
     service.beta.openshift.io/inject-cabundle: "false"
   creationTimestamp: null
-  name: sre-imagecontentpolicies-validation
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    caBundle: '{{.config.serviceca | b64enc }}'
-    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/imagecontentpolicies-validation
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: imagecontentpolicies-validation.managed.openshift.io
-  rules:
-  - apiGroups:
-    - config.openshift.io
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - imagedigestmirrorsets
-    - imagetagmirrorsets
-    scope: Cluster
-  - apiGroups:
-    - operator.openshift.io
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - imagecontentsourcepolicies
-    scope: Cluster
-  sideEffects: None
-  timeoutSeconds: 2
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  annotations:
-    package-operator.run/phase: webhooks
-    service.beta.openshift.io/inject-cabundle: "false"
-  creationTimestamp: null
   name: sre-ingress-config-validation
 webhooks:
 - admissionReviewVersions:

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
@@ -170,7 +170,7 @@ func (w *ImageContentPoliciesWebhook) ClassicEnabled() bool {
 }
 
 func (w *ImageContentPoliciesWebhook) HypershiftEnabled() bool {
-	return true
+	return false
 }
 
 // authorizeImageDigestMirrorSet should reject an ImageDigestMirrorSet that matches an unauthorized mirror list

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
@@ -504,6 +504,13 @@ func TestImageContentPolicy(t *testing.T) {
 					t.Errorf("expected allowed request with code: %d, got %d", http.StatusForbidden, resp.Result.Code)
 				}
 			}
+
+			enabled := hook.HypershiftEnabled()
+
+			if enabled {
+				t.Error("expected to disable in hypershift")
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
## Why
This PR enable ECR image registry configuration on hosted clusters 

## Issue 
https://issues.redhat.com/browse/OSD-24266