### PR TITLE
OSD-13909 - Remove exception allowing prometheusrules to be created in `openshift-monitoring`

### DIFF
--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -84,9 +84,7 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 	if hookconfig.IsPrivilegedNamespace(pr.GetNamespace()) &&
 		// TODO: [OSD-13680] Remove this exception for openshift-customer-monitoring
 		pr.GetNamespace() != "openshift-customer-monitoring" &&
-		pr.GetNamespace() != "openshift-user-workload-monitoring" &&
-		// TODO: [OSD-13909] Remove this exception for openshift-monitoring
-		pr.GetNamespace() != "openshift-monitoring" {
+		pr.GetNamespace() != "openshift-user-workload-monitoring" {
 		log.Info(fmt.Sprintf("%s operation detected on managed namespace: %s", request.Operation, pr.GetNamespace()))
 		if isAllowedUser(request) {
 			ret = admissionctl.Allowed(fmt.Sprintf("User can do operations on PrometheusRules"))


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-13909


---


Reverts an exception in the `prometheusrule` webhook allowing anyone to create `prometheusrule` objects in the `openshift-monitoring` namespace now that [dependent components have been migrated out of the namespace](https://issues.redhat.com/browse/ACM-7631).