### PR TITLE
Minor README.md cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,5 +437,3 @@ pkg/webhooks/namespace
 Commit all changes and deploy as normal.
 
 Once the code changes are complete, remove the undesired `ValidatingWebhookConfiguration` object(s) manually from the cluster.
-
-


### PR DESCRIPTION
Removes extraneous newlines at the end of the README.

Commit is primarily being submitted in order to trigger an automatic rebuild of the codebase, following the merge of https://github.com/openshift/release/pull/56782. 