### PR TITLE
Revert #320 and #321

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.22 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir
@@ -8,7 +8,7 @@ COPY . .
 RUN make build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052
 
 ENV USER_UID=1001 \
     USER_NAME=webhooks


### PR DESCRIPTION
Reverts openshift/managed-cluster-validating-webhooks#320 and openshift/managed-cluster-validating-webhooks#321

These changes are causing the webhooks to crashloop in stage, blocking development work.