### PR TITLE
[OSD-25874]Disable namespace webhook for HCP

### DIFF
--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -319,7 +319,7 @@ func (s *NamespaceWebhook) SyncSetLabelSelector() metav1.LabelSelector {
 
 func (s *NamespaceWebhook) ClassicEnabled() bool { return true }
 
-func (s *NamespaceWebhook) HypershiftEnabled() bool { return true }
+func (s *NamespaceWebhook) HypershiftEnabled() bool { return false }
 
 // NewWebhook creates a new webhook
 func NewWebhook() *NamespaceWebhook {


### PR DESCRIPTION
Disable namespace webhook for HCP, see [OSD-25874](https://issues.redhat.com/browse/OSD-25874) for details