### PR TITLE
OSD-27858 - Fix osde2e test harness image name

### DIFF
--- a/osde2e/project.mk
+++ b/osde2e/project.mk
@@ -1,5 +1,5 @@
 # Project specific values
-OPERATOR_NAME?=$(shell sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' config/config.go)
+OPERATOR_NAME?=managed-cluster-validating-webhooks
 
 HARNESS_IMAGE_REGISTRY?=quay.io
 HARNESS_IMAGE_REPOSITORY?=app-sre


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-27858

---

managed-cluster-validating-webhook changes are not being deployed to stage, as expected. The cause of this appears to be failing a failing make target (`e2e-image-build-push`) in Jenkins.

The make target is attempting to pull images from `http://quay.io/app-sre/validation-webhook-test-harness`, but the repository it should be pulling from is `quay.io/repository/app-sre/managed-cluster-validating-webhooks-test-harness`