### PR TITLE
Revert "OSD-24275: Validate machineCIDR is contained in default ingresscontro…"

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -32,9 +32,6 @@ const (
 	roleName           string = "validation-webhook"
 	prometheusRoleName string = "prometheus-k8s"
 	repoName           string = "managed-cluster-validating-webhooks"
-	// Role and Binding for reading cluster-config-v1 config map...
-	clusterConfigRole        string = "config-v1-reader-wh"
-	clusterConfigRoleBinding string = "validation-webhook-cluster-config-v1-reader"
 	// Used to define what phase a resource should be deployed in by package-operator
 	pkoPhaseAnnotation string = "package-operator.run/phase"
 	// Defines the 'rbac' package-operator phase for any resources related to RBAC
@@ -209,60 +206,6 @@ func createClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			Name:     roleName,
 			Kind:     "ClusterRole",
-			APIGroup: rbacv1.GroupName,
-		},
-	}
-}
-
-func createClusterConfigRole() *rbacv1.Role {
-	return &rbacv1.Role{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Role",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterConfigRole,
-			Namespace: "kube-system",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"configmaps",
-				},
-				Verbs: []string{
-					"get",
-				},
-				ResourceNames: []string{
-					"cluster-config-v1",
-				},
-			},
-		},
-	}
-}
-
-func createClusterConfigRoleBinding() *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "RoleBinding",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterConfigRoleBinding,
-			Namespace: "kube-system",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      serviceAccountName,
-				Namespace: *namespace,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Name:     clusterConfigRole,
-			Kind:     "Role",
 			APIGroup: rbacv1.GroupName,
 		},
 	}
@@ -884,7 +827,6 @@ func sliceContains(needle string, haystack []string) bool {
 
 func main() {
 	flag.Parse()
-	utils.BuildRun = true
 
 	skip := strings.Split(*excludes, ",")
 	onlyInclude := strings.Split(*only, "")
@@ -909,8 +851,6 @@ func main() {
 		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createClusterRoleBinding()})
 		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createPrometheusRole()})
 		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createPromethusRoleBinding()})
-		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createClusterConfigRole()})
-		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createClusterConfigRoleBinding()})
 		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createServiceMonitor()})
 		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createCACertConfigMap()})
 		templateResources.Add(utils.DefaultLabelSelector(), runtime.RawExtension{Object: createService()})

--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -123,35 +123,6 @@ objects:
       - kind: ServiceAccount
         name: prometheus-k8s
         namespace: openshift-monitoring
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        creationTimestamp: null
-        name: config-v1-reader-wh
-        namespace: kube-system
-      rules:
-      - apiGroups:
-        - ""
-        resourceNames:
-        - cluster-config-v1
-        resources:
-        - configmaps
-        verbs:
-        - get
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        creationTimestamp: null
-        name: validation-webhook-cluster-config-v1-reader
-        namespace: kube-system
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: config-v1-reader-wh
-      subjects:
-      - kind: ServiceAccount
-        name: validation-webhook
-        namespace: openshift-validation-webhook
     - apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
 	github.com/openshift/elasticsearch-operator v0.0.0-20220613183908-e1648e67c298 // indirect
-	github.com/openshift/installer v0.16.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.59.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,6 @@ github.com/openshift/elasticsearch-operator v0.0.0-20220613183908-e1648e67c298 h
 github.com/openshift/elasticsearch-operator v0.0.0-20220613183908-e1648e67c298/go.mod h1:6dxhWPY3Wr/0b0eGrFpV7gcyeS+ne48Mo9OQ9dxrLNI=
 github.com/openshift/hive/apis v0.0.0-20230327212335-7fd70848a6d5 h1:adHXZ1WFqCvXpargpTa6divneeUuvV2xr/D6NWgbqS8=
 github.com/openshift/hive/apis v0.0.0-20230327212335-7fd70848a6d5/go.mod h1:VIxA5HhvBmsqVn7aUVQYs004B9K4U5A+HrFwvRq2nK8=
-github.com/openshift/installer v0.16.1 h1:PmjALN9x1NVNVi3SCqfz0ZwVCgOkQLQWo2nHYXREq/A=
-github.com/openshift/installer v0.16.1/go.mod h1:VWGgpJgF8DGCKQjbccnigglhZnHtRLCZ6cxqkXN4Ck0=
 github.com/openshift/operator-custom-metrics v0.5.1 h1:1pk4YMUV+cmqfV0f2fyxY62cl7Gc76kwudJT+EdcfYM=
 github.com/openshift/operator-custom-metrics v0.5.1/go.mod h1:0dYDHi/ubKRWzsC9MmW6bRMdBgo1QSOuAh3GupTe0Sw=
 github.com/openshift/osde2e-common v0.0.0-20231010150014-8a4449a371e6 h1:MPcnO0eeWEyjLBA4mMgJ8pv8u7DjKC7yS+a39R+zhqs=

--- a/pkg/webhooks/ingresscontroller/ingresscontroller.go
+++ b/pkg/webhooks/ingresscontroller/ingresscontroller.go
@@ -1,38 +1,25 @@
 package ingresscontroller
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"net"
 	"net/http"
-	"os"
 	"slices"
 	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	installer "github.com/openshift/installer/pkg/types"
-	"github.com/openshift/managed-cluster-validating-webhooks/pkg/k8sutil"
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
-	"github.com/pkg/errors"
-	admissionv1 "k8s.io/api/admission/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	WebhookName                     string = "ingresscontroller-validation"
 	docString                       string = `Managed OpenShift Customer may create IngressControllers without necessary taints. This can cause those workloads to be provisioned on master nodes.`
 	legacyIngressSupportFeatureFlag        = "ext-managed.openshift.io/legacy-ingress-support"
-	installConfigMap                       = "cluster-config-v1"
-	installConfigNamespace                 = "kube-system"
-	installConfigKeyName                   = "install-config"
 )
 
 var (
@@ -56,8 +43,6 @@ var (
 
 type IngressControllerWebhook struct {
 	s runtime.Scheme
-	// Allow caching install config and machineCIDR values...
-	machineCIDRNet *net.IPNet
 }
 
 // ObjectSelector implements Webhook interface
@@ -160,128 +145,10 @@ func (wh *IngressControllerWebhook) authorized(request admissionctl.Request) adm
 		}
 	}
 
-	/* TODO:
-	 * - Currently only 'classic' handled by this webhook, and 'hypershift' work may or may not follow once defined.
-	 * - HypershiftEnabled is currently set to false/disabled.
-	 * - Classic vs HCP could likely share some of the network funcions, but will need slightly
-	 *   different logic for the different minimum CIDR sets required, different
-	 *   permissions fetching the network config info from different
-	 *   source (configmap) locations, and different parsing of config formats, etc..
-	 */
-	// Only check for machine cidr in allowed ranges if creating or updating resource...
-	reqOp := request.AdmissionRequest.Operation
-	if reqOp == admissionv1.Create || reqOp == admissionv1.Update {
-		if ic.ObjectMeta.Name == "default" && ic.ObjectMeta.Namespace == "openshift-ingress-operator" {
-			ret := wh.checkAllowsMachineCIDR(ic.Spec.EndpointPublishingStrategy.LoadBalancer.AllowedSourceRanges)
-			ret.UID = request.AdmissionRequest.UID
-			if !ret.Allowed {
-				log.Info("Error checking minimum AllowedSourceRange", "err", ret.AdmissionResponse.String())
-			}
-			return ret
-		}
-	}
-	ret = admissionctl.Allowed("IngressController operation is allowed, machineCIDR n/a")
+	ret = admissionctl.Allowed("IngressController operation is allowed")
 	ret.UID = request.AdmissionRequest.UID
 
 	return ret
-}
-
-func (wh *IngressControllerWebhook) getMachineCIDR(instConf *installer.InstallConfig) (*net.IPNet, error) {
-	if wh.machineCIDRNet == nil {
-		if instConf == nil {
-			err := fmt.Errorf("can not fetch machineCIDR from empty '%s' install config", installConfigMap)
-			log.Error(err, "getMachineCIDR failed to find CIDR value")
-			return nil, err
-		}
-		if instConf.Networking.MachineCIDR == nil {
-			err := fmt.Errorf("nil installConfig.machineCIDR value found")
-			log.Error(err, "nil installConfig.machineCIDR value found")
-			return nil, err
-		}
-		if len(instConf.Networking.MachineCIDR.Network()) <= 0 || len(instConf.Networking.MachineCIDR.IPNet.Network()) <= 0 {
-			err := fmt.Errorf("empty machineCIDR network() value parsed from '%s' install config", installConfigMap)
-			log.Error(err, "getMachineCIDR found empty network value")
-			return nil, err
-		}
-		// Successfully fetched, parsed, and converted the machineCIDR string into net structures...
-		wh.machineCIDRNet = &instConf.Networking.MachineCIDR.IPNet
-	}
-	return wh.machineCIDRNet, nil
-}
-
-/* Fetch the install-config from the kube-system config map's data.
- * this requires proper role, rolebinding for this service account's get() request
- * to succeed. (see toplevel selectorsyncset).  This config should not change during runtime so
- * this operation should cache the value(s) if possible.
- * TODO: Should it retry fetching the config if there are any failures/errors encountered while
- * parsing out the the desired values?
- */
-func (wh *IngressControllerWebhook) getClusterConfig() (*installer.InstallConfig, error) {
-	var err error
-
-	kubeClient, err := k8sutil.KubeClient(&wh.s)
-	if err != nil {
-		log.Error(err, "Fail creating KubeClient for IngressControllerWebhook")
-		return nil, err
-	}
-	clusterConfig := &corev1.ConfigMap{}
-	err = kubeClient.Get(context.Background(), client.ObjectKey{Name: installConfigMap, Namespace: installConfigNamespace}, clusterConfig)
-	if err != nil {
-		log.Error(err, fmt.Sprintf("Failed to fetch configmap: '%s' for cluster config", installConfigMap))
-		return nil, err
-	}
-	data, ok := clusterConfig.Data[installConfigKeyName]
-	if !ok {
-		return nil, fmt.Errorf("did not find key %s in configmap %s/%s", installConfigKeyName, installConfigNamespace, installConfigMap)
-	}
-	instConf := &installer.InstallConfig{}
-	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(data)), 4096)
-	if err := decoder.Decode(instConf); err != nil {
-		return nil, errors.Wrap(err, "failed to decode install config")
-	}
-	return instConf, nil
-}
-
-func (wh *IngressControllerWebhook) checkAllowsMachineCIDR(ipRanges []operatorv1.CIDR) admissionctl.Response {
-	// https://docs.openshift.com/container-platform/4.13/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.html
-	// Note: From docs it appears a missing ASR value/attr allows all. However...
-	// once ASR values have been added to an ingresscontroller, later deleting all the ASRs can expose an issue
-	// where the IGC will remaining in progressing state indefinitely.
-	// For now return Allowed, but with a warning?
-	if ipRanges == nil || len(ipRanges) <= 0 {
-		return admissionctl.Allowed("Allowing empty 'AllowedSourceRanges'.")
-	}
-
-	machNetSize, machNetBits := wh.machineCIDRNet.Mask.Size()
-	machineCIDRIP := wh.machineCIDRNet.IP
-	log.Info("Checking AllowedSourceRanges", "MachineCIDR", fmt.Sprintf("%s/%d", machineCIDRIP.String(), machNetSize), "NetBits", machNetBits, "AllowedSourceRanges", ipRanges)
-	for _, OpV1CIDR := range ipRanges {
-		// Clean up the operatorV1.CIDR value into trimmed CIDR 'a.b.c.d/x' string
-		ASRstring := strings.TrimSpace(string(OpV1CIDR))
-		log.Info(fmt.Sprintf("Checking allowed source:'%s'", ASRstring))
-		if len(ASRstring) <= 0 {
-			continue
-		}
-		// Parse the Allowed Source Range Cidr entry into network structures...
-		_, ASRNet, err := net.ParseCIDR(ASRstring)
-		if err != nil {
-			log.Info(fmt.Sprintf("failed to parse AllowedSourceRanges value: '%s'. Err: %s", string(ASRstring), err))
-			return admissionctl.Errored(http.StatusBadRequest, fmt.Errorf("failed to parse AllowedSourceRanges value: '%s'. Err: %s", string(ASRstring), err))
-		}
-		// First check if this AlloweSourceRange entry network contains the machine cidr ip...
-		if !ASRNet.Contains(machineCIDRIP) {
-			//log.Info(fmt.Sprintf("AllowedSourceRange:'%s' does not contain machine CIDR:'%s/%d'", ASRstring, machineCIDRIP.String(), machNetSize))
-			continue
-		}
-		// Check if this AlloweSourceRange entry mask includes the network.
-		ASRNetSize, ASRNetBits := ASRNet.Mask.Size()
-		if machNetBits == ASRNetBits && ASRNetSize <= machNetSize {
-			log.Info(fmt.Sprintf("Found machineCidr:'%s/%d' within AllowedSourceRange:'%s'", machineCIDRIP.String(), machNetSize, ASRstring))
-			return admissionctl.Allowed(fmt.Sprintf("Found machineCidr:'%s/%d' within AllowedSourceRange:'%s'", machineCIDRIP.String(), machNetSize, ASRstring))
-		}
-	}
-	log.Info(fmt.Sprintf("machineCidr:'%s/%d' not found within networks provided by AllowedSourceRanges:'%v'", machineCIDRIP.String(), machNetSize, ipRanges))
-	return admissionctl.Denied(fmt.Sprintf("At least one AllowedSourceRange must allow machine cidr:'%s/%d'", machineCIDRIP.String(), machNetSize))
 }
 
 // isAllowedUser checks if the user is allowed to perform the action
@@ -326,48 +193,9 @@ func (s *IngressControllerWebhook) ClassicEnabled() bool { return true }
 func (s *IngressControllerWebhook) HypershiftEnabled() bool { return false }
 
 // NewWebhook creates a new webhook
-// Allow variadic args so unit tests can provide optional test values...
-func NewWebhook(params ...interface{}) *IngressControllerWebhook {
+func NewWebhook() *IngressControllerWebhook {
 	scheme := runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	if err != nil {
-		log.Error(err, "Fail adding corev1 scheme to IngressControllerWebhook")
-		os.Exit(1)
-	}
-	wh := &IngressControllerWebhook{
+	return &IngressControllerWebhook{
 		s: *scheme,
 	}
-	// utils.TestHooks maps to cli flag 'testhooks' and is used during 'make test' to "test webhook URI uniqueness".
-	// 'make test' does not require this hook to build runtime clients/config at this time...
-	if utils.TestHooks || utils.BuildRun {
-		return wh
-	}
-
-	if len(params) > 0 {
-		param := params[0]
-		// As of know only *IPNet values can be provided by unit tests to set machineCIDR, normal webhook factory
-		// calls NewWebhook() without arguments...
-		if cidr, ok := param.(*net.IPNet); ok {
-			log.Info(fmt.Sprintf("Got test net.IPNet param network() for machineCIDR:'%s'\n", cidr.Network()))
-			wh.machineCIDRNet = cidr
-		} else {
-			log.Error(fmt.Errorf("invalid test param provided, expected *net.IPNet machineCIDR value"), "invalid test param provided, expected *net.IPNet machineCIDR value")
-			os.Exit(1)
-		}
-	} else {
-		// This is not a test run.
-		// Try to populate machine cidr at init. Exit with error if this fails...
-		instConf, err := wh.getClusterConfig()
-		if err != nil {
-			log.Error(err, "Failed to fetch configmap for machineCIDR", "namespace", installConfigNamespace, "configmap", installConfigMap)
-			os.Exit(1)
-		}
-
-		_, err = wh.getMachineCIDR(instConf)
-		if err != nil || wh.machineCIDRNet == nil {
-			log.Error(err, "Failed to fetch cluster machineCIDR.")
-			os.Exit(1)
-		}
-	}
-	return wh
 }

--- a/pkg/webhooks/ingresscontroller/ingresscontroller_test.go
+++ b/pkg/webhooks/ingresscontroller/ingresscontroller_test.go
@@ -3,14 +3,10 @@ package ingresscontroller
 import (
 	"encoding/json"
 	"fmt"
-	"net"
-	"os"
 	"testing"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/managed-cluster-validating-webhooks/pkg/testutils"
 	admissionv1 "k8s.io/api/admission/v1"
-	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,7 +32,6 @@ const template string = `{
         "domain": "apps.dummy.devshift.org",
         "endpointPublishingStrategy": {
             "loadBalancer": {
-				%s
                 "providerParameters": {
                     "aws": {
                         "classicLoadBalancer": {
@@ -66,8 +61,7 @@ const template string = `{
   }
   `
 
-func createRawIngressControllerJSON(name string, namespace string, nodeSelector corev1.NodeSelector, tolerations []corev1.Toleration, allowedRanges []operatorv1.CIDR) (string, error) {
-	var AllowedSourceRangesPartial string = ""
+func createRawIngressControllerJSON(name string, namespace string, nodeSelector corev1.NodeSelector, tolerations []corev1.Toleration) (string, error) {
 	nodeSelectorPartial, err := json.Marshal(nodeSelector)
 	if err != nil {
 		return "", err
@@ -76,31 +70,22 @@ func createRawIngressControllerJSON(name string, namespace string, nodeSelector 
 	if err != nil {
 		return "", err
 	}
-	// Allow a nil value to exclude the 'allowedSourceRanges' param from the request.
-	if allowedRanges != nil {
-		ASRString, err := json.Marshal(allowedRanges)
-		if err != nil {
-			return "", err
-		}
-		AllowedSourceRangesPartial = fmt.Sprintf("\"allowedSourceRanges\": %s,", ASRString)
-	}
 
-	output := fmt.Sprintf(template, name, namespace, string(AllowedSourceRangesPartial), string(nodeSelectorPartial), string(tolerationsPartial))
+	output := fmt.Sprintf(template, name, namespace, string(nodeSelectorPartial), string(tolerationsPartial))
+
 	return output, nil
 }
 
 type ingressControllerTestSuites struct {
-	testID              string
-	name                string
-	namespace           string
-	username            string
-	userGroups          []string
-	operation           admissionv1.Operation
-	nodeSelector        corev1.NodeSelector
-	tolerations         []corev1.Toleration
-	allowedSourceRanges []operatorv1.CIDR
-	machineCIDR         string
-	shouldBeAllowed     bool
+	testID          string
+	name            string
+	namespace       string
+	username        string
+	userGroups      []string
+	operation       admissionv1.Operation
+	nodeSelector    corev1.NodeSelector
+	tolerations     []corev1.Toleration
+	shouldBeAllowed bool
 }
 
 func runIngressControllerTests(t *testing.T, tests []ingressControllerTestSuites) {
@@ -115,10 +100,8 @@ func runIngressControllerTests(t *testing.T, tests []ingressControllerTestSuites
 		Resource: "ingresscontroller",
 	}
 	for _, test := range tests {
-		//fmt.Fprintf(os.Stderr, "Starting test:'%s'\n", test.testID)
-		rawObjString, err := createRawIngressControllerJSON(test.name, test.namespace, test.nodeSelector, test.tolerations, test.allowedSourceRanges)
+		rawObjString, err := createRawIngressControllerJSON(test.name, test.namespace, test.nodeSelector, test.tolerations)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Couldn't create a JSON fragment %s \n", err.Error())
 			t.Fatalf("Couldn't create a JSON fragment %s", err.Error())
 		}
 
@@ -129,55 +112,27 @@ func runIngressControllerTests(t *testing.T, tests []ingressControllerTestSuites
 		oldObj := runtime.RawExtension{
 			Raw: []byte(rawObjString),
 		}
-		cidr, err := getMachineCidr(t, test.machineCIDR)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Expected no error, got err parsing machineCIDR:'%s', got '%s'\n", string(test.machineCIDR), err.Error())
-			t.Fatalf("Expected no error, got err parsing machineCIDR:'%s', got '%s'", string(test.machineCIDR), err.Error())
-		}
-		hook := NewWebhook(cidr)
+
+		hook := NewWebhook()
 		httprequest, err := testutils.CreateHTTPRequest(hook.GetURI(), test.testID, gvk, gvr, test.operation, test.username, test.userGroups, "", &obj, &oldObj)
 
 		if err != nil {
-			t.Logf("Request object:'%s'", obj)
-			// go test is quirky about muting its logger when run against more than 1 package
-			fmt.Fprintf(os.Stderr, "Expected no error, got %s \n", err.Error())
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}
 
 		response, err := testutils.SendHTTPRequest(httprequest, hook)
 		if err != nil {
-			// go test is quirky about muting its logger when run against more than 1 package
-			fmt.Fprintf(os.Stderr, "Expected no error, got %s", err.Error())
 			t.Fatalf("Expected no error, got %s", err.Error())
 		}
 		if response.UID == "" {
-			//t.Logf("Request object:'%s'", obj)
-			// go test is quirky about muting its logger when run against more than 1 package
-			fmt.Fprintf(os.Stderr, "No tracking UID associated with the response.")
-			t.Logf("Response object:'%v'", response)
 			t.Fatalf("No tracking UID associated with the response.")
 		}
 
 		if response.Allowed != test.shouldBeAllowed {
-			t.Logf("%s", obj)
-			t.Logf("Response.reason:'%v'", response)
-			// go test is quirky about muting its logger when run against more than 1 package
-			fmt.Fprintf(os.Stderr, "[%s] Mismatch: %s (groups=%s) %s %s the ingress controller. Test's expectation is that the user %s", test.testID, test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
 			t.Fatalf("[%s] Mismatch: %s (groups=%s) %s %s the ingress controller. Test's expectation is that the user %s", test.testID, test.username, test.userGroups, testutils.CanCanNot(response.Allowed), test.operation, testutils.CanCanNot(test.shouldBeAllowed))
-		}
-		//fmt.Fprintf(os.Stderr, "Finished Success: '%s'\n", test.testID)
-	}
-}
 
-func getMachineCidr(t *testing.T, machineCIDR string) (*net.IPNet, error) {
-	if len(machineCIDR) <= 0 {
-		machineCIDR = "10.0.0.0/16"
+		}
 	}
-	_, net, err := net.ParseCIDR(string(machineCIDR))
-	if err != nil {
-		t.Fatalf("Expected no error, got err parsing machineCIDR:'%s', got '%s'", string(machineCIDR), err.Error())
-	}
-	return net, nil
 }
 
 func TestIngressControllerTolerations(t *testing.T) {
@@ -406,227 +361,4 @@ func TestIngressControllerExceptions(t *testing.T) {
 		},
 	}
 	runIngressControllerTests(t, tests)
-}
-
-func runIngressControllerAllowedSourceRangesTests(t *testing.T, op admissionv1.Operation) {
-	tests := []ingressControllerTestSuites{
-		{
-			testID:      fmt.Sprintf("allowedSourceRanges-test-missing-allowedSourceRanges-%s", op),
-			name:        "default",
-			namespace:   "openshift-ingress-operator",
-			username:    "admin",
-			userGroups:  []string{"system:authenticated", "cluster-admins"},
-			operation:   op,
-			machineCIDR: "10.0.0.0/16",
-			//AllowedSourceRanges: nil,
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-empty-allowedSourceRanges-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-include-only-machineCIDR-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"10.0.0.0/8"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-include-many-before-machineCIDR-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"10.0.0.0/8", "192.168.1.0/24", "172.20.4.0/16"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-include-many-after-machineCIDR-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"192.168.1.0/24", "172.20.4.0/16", "10.0.0.0/8"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-exclude-single-machineCIDR-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"192.168.1.0/24"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: false,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-exclude-many-machineCIDR-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"192.168.1.0/24", "192.168.1.0/16", "172.20.4.5/32", "10.0.0.0/17"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: false,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-invalid-network-value-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"10"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: false,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-invalid-input-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"ABC"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: false,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-include-machineCIDR-with-ipv6-%s", op),
-			name:                "default",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"2001:db8:abcd:1234::1/64", "10.0.0.0/16"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-	}
-	runIngressControllerTests(t, tests)
-}
-
-func TestIngressControllerAllowedSourceRangesCreate(t *testing.T) {
-	// Test the update and create operations in parallel?
-	t.Parallel()
-	runIngressControllerAllowedSourceRangesTests(t, admissionv1.Create)
-}
-
-func TestIngressControllerAllowedSourceRangesUpdate(t *testing.T) {
-	// Test the update and create operations in parallel?
-	t.Parallel()
-	runIngressControllerAllowedSourceRangesTests(t, admissionv1.Update)
-}
-
-func runIngressControllerAllowedSourceRangesNonDefaultTest(t *testing.T, op admissionv1.Operation) {
-	tests := []ingressControllerTestSuites{
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-non-default-exclude-machineCIDR-%s", op),
-			name:                "shiny-newingress",
-			namespace:           "openshift-ingress-operator",
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"192.168.1.0/24", "172.20.4.0/24"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:              fmt.Sprintf("allowedSourceRanges-test-non-os-namespace-exclude-machineCIDR-%s", op),
-			name:                "default",
-			namespace:           "shiny-newingress-namespace", //May not be a valid test beyond testing  the webhook.
-			username:            "admin",
-			userGroups:          []string{"system:authenticated", "cluster-admins"},
-			operation:           op,
-			machineCIDR:         "10.0.0.0/16",
-			allowedSourceRanges: []operatorv1.CIDR{"192.168.1.0/24", "172.20.4.0/24"},
-			nodeSelector: corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-			},
-			tolerations:     []corev1.Toleration{},
-			shouldBeAllowed: true,
-		},
-	}
-	runIngressControllerTests(t, tests)
-}
-
-func TestIngressControllerAllowedSourceRangesNonDefaultCreate(t *testing.T) {
-	runIngressControllerAllowedSourceRangesTests(t, admissionv1.Create)
-}
-func TestIngressControllerAllowedSourceRangesNonDefaultUpdate(t *testing.T) {
-	runIngressControllerAllowedSourceRangesTests(t, admissionv1.Update)
-}
-
-func TestIngressControllerCheckDeleteSupport(t *testing.T) {
-	hook := NewWebhook(getMachineCidr(t, ""))
-	rules := hook.Rules()
-	for _, rule := range rules {
-		for _, op := range rule.Operations {
-			if op == admissionregv1.OperationType(admissionv1.Delete) {
-				t.Fatalf("IngressController web hook is supporting the Delete operation. Replace this check with unit tests supporting 'Delete'")
-			}
-		}
-	}
 }

--- a/pkg/webhooks/utils/utils.go
+++ b/pkg/webhooks/utils/utils.go
@@ -26,9 +26,6 @@ const (
 )
 
 var (
-	// Allows sharing of testhooks 'make test' flag value used by main to test "webhook URI uniqueness"
-	TestHooks       bool
-	BuildRun        bool
 	admissionScheme = runtime.NewScheme()
 	admissionCodecs = serializer.NewCodecFactory(admissionScheme)
 )


### PR DESCRIPTION
Reverts openshift/managed-cluster-validating-webhooks#318, as it's unintentionally been deployed to the HyperShift staging environment, where it's crashlooping the webhook pods