### PR TITLE
OSD-21711: Fix admin username that can bypass SDN webhook

### DIFF
--- a/pkg/webhooks/sdnmigration/sdnmigration.go
+++ b/pkg/webhooks/sdnmigration/sdnmigration.go
@@ -19,7 +19,7 @@ const (
 	WebhookName               string = "sdn-migration-validation"
 	docString                 string = `Managed OpenShift customers may not modify the network config type because it can can degrade cluster operators and can interfere with OpenShift SRE monitoring.`
 	overrideAnnotation        string = "unsupported-red-hat-internal-testing"
-	privilegedHiveUserAccount string = "admin-kubeconfig-signer"
+	privilegedHiveUserAccount string = "system:admin"
 )
 
 var (

--- a/pkg/webhooks/sdnmigration/sdnmigration_test.go
+++ b/pkg/webhooks/sdnmigration/sdnmigration_test.go
@@ -32,8 +32,9 @@ func TestAuthorized(t *testing.T) {
 			},
 			ExpectAllowed: true,
 		},
+		// Hive uses the admin user and we need to bypass the webhook for Hive
 		{
-			Name: "system admin should be denied",
+			Name: "system admin should be allowed",
 			Request: admissionctl.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					UserInfo: authenticationv1.UserInfo{
@@ -41,7 +42,7 @@ func TestAuthorized(t *testing.T) {
 					},
 				},
 			},
-			ExpectAllowed: false,
+			ExpectAllowed: true,
 		},
 		{
 			Name: "non-privileged account should be denied",


### PR DESCRIPTION
When testing this via a hive sync I noticed it was failing. After further inspection of the certificate Hive uses, the `cn` was wrong. Looks like we took the value from the `Issuer`

```
        Issuer: OU=openshift, CN=admin-kubeconfig-signer
        Validity
            Not Before: Jan 30 17:42:34 2025 GMT
            Not After : Jan 28 17:42:34 2035 GMT
        Subject: O=system:masters, CN=system:admin
```