### PR TITLE
OSD-28159 - Enable OLM Skip Range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 const (
 	// I know this isn't the operator's name but so much stuff has been coded to use this...
-	OperatorName      = "validation-webhook"
-	OperatorNamespace = "openshift-validation-webhook"
+	OperatorName       = "validation-webhook"
+	OperatorNamespace  = "openshift-validation-webhook"
+	EnableOLMSkipRange = "true"
 )


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range pointing to the latest version. This will allow OLM to upgrade past broken replaces chains in which versions get abadoned without a path forward. The new OLM bundle will contain a single version, referencing the latest build with a skipRange to the version. Part of [OSD-28159](https://issues.redhat.com//browse/OSD-28159) ticket.