### PR TITLE
[OSD-19341] Remove exception allowing prometheusrules to be created in 'openshift-customer-monitoring' & 'openshift-user-workload-monitoring'

### DIFF
--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -80,10 +80,7 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 		return admissionctl.Errored(http.StatusBadRequest, err)
 	}
 
-	if hookconfig.IsPrivilegedNamespace(pr.GetNamespace()) &&
-		// TODO: [OSD-13680] Remove this exception for openshift-customer-monitoring
-		pr.GetNamespace() != "openshift-customer-monitoring" &&
-		pr.GetNamespace() != "openshift-user-workload-monitoring" {
+	if hookconfig.IsPrivilegedNamespace(pr.GetNamespace()) {
 		log.Info(fmt.Sprintf("%s operation detected on managed namespace: %s", request.Operation, pr.GetNamespace()))
 		if isAllowedUser(request) {
 			ret = admissionctl.Allowed(fmt.Sprintf("User can do operations on PrometheusRules"))

--- a/pkg/webhooks/prometheusrule/prometheusrule_test.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule_test.go
@@ -255,7 +255,7 @@ func TestUsers(t *testing.T) {
 			username:        "prometheus-user-workload",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
 			testID:          "regular-user-can-create-prometheusrule-in-openshift-user-workload-monitoring",
@@ -264,7 +264,7 @@ func TestUsers(t *testing.T) {
 			username:        "prometheus-user-workload",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Delete,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
 			testID:          "serviceaccount-in-managed-namespaces-can-create-prometheusrule-in-openshift-user-workload-monitoring",
@@ -273,7 +273,7 @@ func TestUsers(t *testing.T) {
 			username:        "prometheus-user-workload",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Update,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
 			testID:          "serviceaccount-in-managed-namespaces-can-create-prometheusrule-in-redhat-rhoam-observability",


### PR DESCRIPTION
[OSD-19341](https://issues.redhat.com/browse/OSD-19341)

Reverts an exception in the `prometheusrule webhook` allowing anyone to create `prometheusrule` objects in the `openshift-customer-monitoring` & `openshift-user-workload-monitoring` namespace. The exception was created to unblock APP-SRE migration workload monitoring off of openshift-customer-monitoring (https://issues.redhat.com/browse/APPSRE-6523 / [OSD-13680](https://issues.redhat.com/browse/OSD-13680))