### PR TITLE
Ensure namespace is created before creating any cluster resources

### DIFF
--- a/test/e2e/managed_cluster_validating_webhooks_test.go
+++ b/test/e2e/managed_cluster_validating_webhooks_test.go
@@ -48,14 +48,31 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 		testNamespace      *v1.Namespace
 	)
 	const (
-		namespaceName = "openshift-validation-webhook"
-		serviceName   = "validation-webhook"
-		daemonsetName = "validation-webhook"
-		configMapName = "webhook-cert"
-		secretName    = "webhook-cert"
-		saName        = "webhook-sa"
-		testNsName    = "osde2e-temp-ns"
+		namespaceName         = "openshift-validation-webhook"
+		serviceName           = "validation-webhook"
+		daemonsetName         = "validation-webhook"
+		configMapName         = "webhook-cert"
+		secretName            = "webhook-cert"
+		testNsName            = "osde2e-temp-ns"
+		privilegedNamespace   = "openshift-backplane"
+		unprivilegedNamespace = "openshift-logging"
 	)
+
+	createNS := func(ns string) {
+		testNamespace = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+		err := client.Create(context.TODO(), testNamespace)
+		By("checking the custom namespace exists")
+		err = wait.For(conditions.New(client.Resources).ResourceMatch(testNamespace, func(object k8s.Object) bool {
+			return true
+		}))
+		Expect(err).ShouldNot(HaveOccurred(), "Unable to create test namespace")
+	}
+
+	deleteNS := func(ns *v1.Namespace) {
+		err := client.Delete(context.TODO(), ns)
+		err = wait.For(conditions.New(client.Resources).ResourceDeleted(ns))
+		Expect(err).ShouldNot(HaveOccurred(), "Unable to delete test namespace")
+	}
 
 	BeforeAll(func() {
 		log.SetLogger(GinkgoLogr)
@@ -133,6 +150,8 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 		}
 
 		err := client.Create(context.TODO(), pod)
+		Expect(err).NotTo(HaveOccurred())
+		err = client.Delete(ctx, pod)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -218,23 +237,16 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 		}, SpecTimeout(createPodWaitDuration.Seconds()+deletePodWaitDuration.Seconds()))
 
 		It("allows cluster-admin to schedule pods onto master/infra nodes", func(ctx context.Context) {
-			sa := &v1.ServiceAccount{}
-
-			err := client.Get(ctx, saName, namespaceName, sa)
-
-			if err == nil {
-				err = client.Delete(ctx, sa)
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete existing Service Account")
-			}
-
-			sa = &v1.ServiceAccount{
+			sa := &v1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      saName,
+					Name:      "webhook-sa",
 					Namespace: namespaceName,
 				},
 			}
-			err = client.Create(ctx, sa)
+			err := client.Create(ctx, sa)
 			Expect(err).ShouldNot(HaveOccurred(), "Unable to create service account")
+			err = client.Delete(ctx, sa)
+			Expect(err).ShouldNot(HaveOccurred(), "Unable to delete service account")
 
 			pod = withNamespace(pod, privilegedNamespace)
 			err = client.Create(ctx, pod)
@@ -320,21 +332,17 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 		)
 
 		BeforeAll(func(ctx context.Context) {
-			testNamespace = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNsName}}
-			err := client.Create(ctx, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred(), "Unable to create test namespace")
+			createNS(testNsName)
+		})
+
+		AfterAll(func(ctx context.Context) {
+			deleteNS(testNamespace)
 		})
 
 		It("only blocks configmap/user-ca-bundle changes", func(ctx context.Context) {
 			cm := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "user-ca-bundle", Namespace: "openshift-config"}}
 			err := dedicatedAdmink8s.Delete(ctx, cm)
 			Expect(errors.IsForbidden(err)).To(BeTrue(), "Expected to be forbidden from deleting user-ca-bundle ConfigMap")
-
-			By("checking the custom namespace exists")
-			err = wait.For(conditions.New(client.Resources).ResourceMatch(testNamespace, func(object k8s.Object) bool {
-				return true
-			}))
-			Expect(err).ToNot(HaveOccurred())
 
 			cm = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNsName},
@@ -527,7 +535,7 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		updateNamespace := func(ctx context.Context, name string, user string, groups ...string) error {
+		updateNamespace := func(ctx context.Context, name, user string, groups ...string) error {
 			userk8s, err := client.Impersonate(user, groups...)
 			if err != nil {
 				return err
@@ -619,10 +627,11 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 			rule := newPrometheusRule(privilegedNamespace)
 			err = client.Delete(ctx, rule)
 			Expect(err == nil || errors.IsNotFound(err)).To(BeTrue(), "Failed to ensure PrometheusRule deletion")
+			createNS(testNsName)
 		})
 
 		AfterAll(func(ctx context.Context) {
-			client.Delete(ctx, testNamespace)
+			deleteNS(testNamespace)
 		})
 
 		DescribeTable(

--- a/test/e2e/managed_cluster_validating_webhooks_test.go
+++ b/test/e2e/managed_cluster_validating_webhooks_test.go
@@ -330,6 +330,12 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 			err := dedicatedAdmink8s.Delete(ctx, cm)
 			Expect(errors.IsForbidden(err)).To(BeTrue(), "Expected to be forbidden from deleting user-ca-bundle ConfigMap")
 
+			By("checking the custom namespace exists")
+			err = wait.For(conditions.New(client.Resources).ResourceMatch(testNamespace, func(object k8s.Object) bool {
+				return true
+			}))
+			Expect(err).ToNot(HaveOccurred())
+
 			cm = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNsName},
 				Data:       map[string]string{"test": "test"},


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28343

This has been tested extensively, running both the full suite and individual tests that were previously failing to ensure that there is no flakiness.

In addition, it cleans up the test pod, the webhook-sa test sa and the test namespace that hadn't been cleaned up and would still be in the cluster after test runs.