### PR TITLE
OSD-28850 - add the openshift-kube-apiserver-operator serviceaccount to the SCC allowlist

### DIFF
--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -36,6 +36,7 @@ var (
 		},
 	}
 	allowedUsers = []string{
+		"system:serviceaccount:openshift-kube-apiserver-operator:kube-apiserver-operator",
 		"system:serviceaccount:openshift-monitoring:cluster-monitoring-operator",
 		"system:serviceaccount:openshift-cluster-version:default",
 		"system:admin",

--- a/pkg/webhooks/scc/scc_test.go
+++ b/pkg/webhooks/scc/scc_test.go
@@ -169,6 +169,14 @@ func TestUser(t *testing.T) {
 			userGroups:      []string{"system:authenticated", "system:serviceaccounts:osde2e-abcde"},
 			shouldBeAllowed: false,
 		},
+		{
+			targetSCC:       "anyuid",
+			testID:          "kube-apiserver-operator-allowed",
+			username:        "system:serviceaccount:openshift-kube-apiserver-operator:kube-apiserver-operator",
+			operation:       admissionv1.Update,
+			userGroups:      []string{},
+			shouldBeAllowed: true,
+		},
 	}
 	runSCCTests(t, tests)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-28850

---

Adds the `openshift-kube-apiserver-operator`'s serviceaccount to the SCC webhook's allowlist, granting the kube-apiserver-operator the ability to freely manage SCCs without SRE interference.