### PR TITLE
Add exception for openshift-customer-monitoring for the PrometheusRule webhook

### DIFF
--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -80,7 +80,10 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 		return admissionctl.Errored(http.StatusBadRequest, err)
 	}
 
-	if hookconfig.IsPrivilegedNamespace(pr.GetNamespace()) {
+	if hookconfig.IsPrivilegedNamespace(pr.GetNamespace()) &&
+		// TODO: [OSD-13680] Remove this exception for openshift-customer-monitoring
+		pr.GetNamespace() != "openshift-customer-monitoring" &&
+		pr.GetNamespace() != "openshift-user-workload-monitoring" {
 		log.Info(fmt.Sprintf("%s operation detected on managed namespace: %s", request.Operation, pr.GetNamespace()))
 		if isAllowedUser(request) {
 			ret = admissionctl.Allowed(fmt.Sprintf("User can do operations on PrometheusRules"))

--- a/pkg/webhooks/prometheusrule/prometheusrule_test.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule_test.go
@@ -255,7 +255,7 @@ func TestUsers(t *testing.T) {
 			username:        "prometheus-user-workload",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
-			shouldBeAllowed: false,
+			shouldBeAllowed: true,
 		},
 		{
 			testID:          "regular-user-can-create-prometheusrule-in-openshift-user-workload-monitoring",
@@ -264,7 +264,7 @@ func TestUsers(t *testing.T) {
 			username:        "prometheus-user-workload",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Delete,
-			shouldBeAllowed: false,
+			shouldBeAllowed: true,
 		},
 		{
 			testID:          "serviceaccount-in-managed-namespaces-can-create-prometheusrule-in-openshift-user-workload-monitoring",
@@ -273,7 +273,7 @@ func TestUsers(t *testing.T) {
 			username:        "prometheus-user-workload",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Update,
-			shouldBeAllowed: false,
+			shouldBeAllowed: true,
 		},
 		{
 			testID:          "serviceaccount-in-managed-namespaces-can-create-prometheusrule-in-redhat-rhoam-observability",


### PR DESCRIPTION
Reverting https://github.com/openshift/managed-cluster-validating-webhooks/pull/349 change, App SRE still uses the openshift-customer-monitoring ns and removing the exception cause [errors](https://console-openshift-console.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/k8s/ns/app-interface-production/pods/qontract-reconcile-openshift-prometheus-rules-1-5595c6dbb79r2n6/logs) and blocking https://issues.redhat.com/browse/ASIC-629

[OHSS-43133](https://issues.redhat.com/browse/OHSS-43133)