### PR TITLE
SREP-1565 - Remove cluster-admins exception from namespaces webhook

### DIFF
--- a/pkg/webhooks/namespace/namespace.go
+++ b/pkg/webhooks/namespace/namespace.go
@@ -25,7 +25,6 @@ const (
 	layeredProductNamespace      string = `^redhat-.*`
 	layeredProductAdminGroupName string = "layered-sre-cluster-admins"
 	docString                    string = `Managed OpenShift Customers may not modify namespaces specified in the %v ConfigMaps because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression %s because it could interfere with critical DNS resolution. Additionally, customers may not set or change the values of these Namespace labels %s.`
-	clusterAdminGroup            string = "cluster-admins"
 )
 
 // exported vars to be used across packages
@@ -338,7 +337,7 @@ func NewWebhook() *NamespaceWebhook {
 }
 
 func amIAdmin(request admissionctl.Request) bool {
-	if slices.Contains(clusterAdminUsers, request.UserInfo.Username) || slices.Contains(request.UserInfo.Groups, clusterAdminGroup) {
+	if slices.Contains(clusterAdminUsers, request.UserInfo.Username) {
 		return true
 	}
 

--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -717,13 +717,13 @@ func TestAdminUser(t *testing.T) {
 			shouldBeAllowed: true,
 		},
 		{
-			// admin users gonna admin
+			// cluster-admin users cannot update privilegedNamespaces
 			testID:          "cluster-admin-test",
 			targetNamespace: privilegedNamespace,
 			username:        "lisa",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Update,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
 			// admin users gonna admin
@@ -762,40 +762,31 @@ func TestAdminUser(t *testing.T) {
 			shouldBeAllowed: true,
 		},
 		{
-			// Admins should be able to create a privileged namespace
-			testID:          "cluster-admin-in-ns-test",
+			// cluster-admin group members should not be able to create a privileged namespace
+			testID:          "cluster-admin-group-in-ns-test",
 			targetNamespace: "in",
 			username:        "lisa",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
-			// Admins should be able to create a privileged namespace
-			testID:          "cluster-admin-in-ns-test",
-			targetNamespace: privilegedNamespace,
-			username:        "lisa",
-			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
-			operation:       admissionv1.Create,
-			shouldBeAllowed: true,
-		},
-		{
-			// Admins should be able to update a privileged namespace
+			// cluster-admin group members should not be able to update a privileged namespace
 			testID:          "cluster-admin-in-ns-test",
 			targetNamespace: privilegedNamespace,
 			username:        "lisa",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Update,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
-			// Admins should be able to delete a privileged namespace
+			// cluster-admins group members should not be able to delete a privileged namespace
 			testID:          "cluster-admin-in-ns-test",
 			targetNamespace: privilegedNamespace,
 			username:        "lisa",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Delete,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 	}
 	runNamespaceTests(t, tests)
@@ -825,25 +816,13 @@ func TestLabelCreates(t *testing.T) {
 			shouldBeAllowed: true,
 		},
 		{
-			testID:          "cluster-admin-can-create-priv-labelled-ns",
+			testID:          "cluster-admins-group-cannot-create-priv-labelled-ns",
 			targetNamespace: privilegedNamespace,
 			username:        "no-reply@redhat.com",
 			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
 			labels:          map[string]string{"my-label": "hello"},
-			shouldBeAllowed: true,
-		},
-		{
-			testID:          "cluster-admins-can-create-priv-labelled-ns",
-			targetNamespace: privilegedNamespace,
-			username:        "no-reply@redhat.com",
-			userGroups:      []string{"cluster-admins", "system:authenticated", "system:authenticated:oauth"},
-			operation:       admissionv1.Create,
-			labels: map[string]string{
-				"managed.openshift.io/storage-pv-quota-exempt": "true",
-				"managed.openshift.io/storage-lb-quota-exempt": "true",
-			},
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
 			testID:          "admin-test",


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-1565

---

Removes an exception in the namespaces webhook which allows members of the cluster-admins group, the group customer users are added to when granted cluster-admin privileges in OCM, to modify platform-namespaces and privileged labels which can impact their SLA. It does not impact `backplane-cluster-admin` group members nor `layered-sre-cluster-admins`. 