### PR TITLE
OSD-31063:Removing the on-cel-expression to fix the jenkins build

### DIFF
--- a/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: | 
-      event == "pull_request" 
-      && target_branch == "master"
-      && ("{.,**}/*.go".pathChanged() ||
-          "{.,**}/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-cluster-validating-webhooks

--- a/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" 
-      && target_branch == "master"
-      && ("{.,**}/*.go".pathChanged() ||
-          "{.,**}/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/managed-cluster-validating-webhooks-e2e-push.yaml".pathChanged() ) 
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-cluster-validating-webhooks

--- a/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: | 
-      event == "pull_request" 
-      && target_branch == "master"
-      && ("{.,**}/*.go".pathChanged() ||
-          "{.,**}/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/managed-cluster-validating-webhooks-pull-request.yaml".pathChanged() )  
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-cluster-validating-webhooks

--- a/.tekton/managed-cluster-validating-webhooks-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" 
-      && target_branch == "master"
-      && ("{.,**}/*.go".pathChanged() ||
-          "{.,**}/go.*".pathChanged() ||
-          "build/Dockerfile".pathChanged() ||
-          ".tekton/managed-cluster-validating-webhooks-push.yaml".pathChanged() )  
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: managed-cluster-validating-webhooks


### PR DESCRIPTION
**What is this change?**

This change removes the usage of the on-cel-expression from the Jenkins pipeline configuration to resolve build failures encountered during Jenkins runs.

**Why is this needed?**
The existing on-cel-expression was causing the Jenkins build to fail in the Jenkins environment. 
