### PR TITLE
SREP-1770 - Allow nvidia-gpu-operator to label unprotected namespaces with `openshift.io/cluster-monitoring: "true"`

### DIFF
--- a/pkg/webhooks/namespace/namespace_test.go
+++ b/pkg/webhooks/namespace/namespace_test.go
@@ -1102,6 +1102,41 @@ func TestLabellingUpdates(t *testing.T) {
 			labels:          map[string]string{},
 			shouldBeAllowed: true,
 		},
+		// https://issues.redhat.com/browse/SREP-1770 - test explicit exception for nvidia-gpu-operator
+		{
+			testID:          "nvidia-gpu-operator-can-add-label-to-unprotected-ns",
+			targetNamespace: "nvidia-gpu-operator",
+			username:        "system:serviceaccount:nvidia-gpu-operator:gpu-operator",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			oldObject:       createOldObject("nvidia-gpu-operator", "nvidia-gpu-operato-can-add-label-to-unprotected-ns", map[string]string{}),
+			labels:          map[string]string{"openshift.io/cluster-monitoring": "true"},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:          "nvidia-gpu-operator-can-remove-label-from-unprotected-ns",
+			targetNamespace: "nvidia-gpu-operator",
+			username:        "system:serviceaccount:nvidia-gpu-operator:gpu-operator",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			oldObject: createOldObject("nvidia-gpu-operator", "nvidia-gpu-operato-can-remove-label-from-unprotected-ns", map[string]string{
+				"openshift.io/cluster-monitoring": "true",
+			}),
+			labels:          map[string]string{},
+			shouldBeAllowed: true,
+		},
+		{
+			testID:          "nvidia-gpu-operator-cannot-remove-label-from-protected-ns",
+			targetNamespace: "nvidia-gpu-operator",
+			username:        "system:serviceaccount:nvidia-gpu-operator:gpu-operator",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Update,
+			oldObject: createOldObject("openshift-kube-apiserver", "nvidia-gpu-operato-cannot-remove-label-from-protected-ns", map[string]string{
+				"openshift.io/cluster-monitoring": "true",
+			}),
+			labels:          map[string]string{},
+			shouldBeAllowed: false,
+		},
 	}
 	runNamespaceTests(t, tests)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-1770

---

Adds an explicit exception to the managed-cluster-validating-webhooks which allows the nvidia-gpu-operator to manage labels on unprotected namespaces. 

This exception is limited to the `gpu-operator` serviceaccount in the `nvidia-gpu-operator` namespace. While OperatorHub allows the operator to be installed into any project, [Nvidia docs](https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/install-gpu-ocp.html#installing-the-nvidia-gpu-operator-by-using-the-web-console) indicate this label is only added by the operator when installed in that namespace.

Changes were validated by installing the operator via OperatorHub, [creating a ClusterPolicy CR](https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/install-gpu-ocp.html#create-the-cluster-policy-using-the-cli), and observing the operator logs. Without these changes, the operator's namespace update was getting rejected:

```
{"level":"info","ts":"2025-09-10T17:12:19Z","logger":"controllers.ClusterPolicy","msg":"Monitoring can be disabled by setting the namespace label openshift.io/cluster-monitoring=false"}
{"level":"error","ts":"2025-09-10T17:12:19Z","logger":"controllers.ClusterPolicy","msg":"Failed to initialize ClusterPolicy controller: Unable to label namespace nvidia-gpu-operator for the GPU Operator monitoring, err admission webhook \"namespace-validation.managed.openshift.io\" denied the request: Denied. Err Managed OpenShift customers may only remove the following protected labels from Namespaces: ([openshift.io/cluster-monitoring])"}
{"level":"error","ts":"2025-09-10T17:12:19Z","logger":"controllers.ClusterPolicy","msg":"ClusterPolicy.nvidia.com \"gpu-cluster-policy\" is invalid: status.state: Unsupported value: \"\": supported values: \"ignored\", \"ready\", \"notReady\""}
{"level":"error","ts":"2025-09-10T17:12:19Z","msg":"Reconciler error","controller":"clusterpolicy-controller","object":{"name":"gpu-cluster-policy"},"namespace":"","name":"gpu-cluster-policy","reconcileID":"06beef39-602d-4a17-a37e-404813280caf","error":"Failed to initialize ClusterPolicy controller: Unable to label namespace nvidia-gpu-operator for the GPU Operator monitoring, err admission webhook \"namespace-validation.managed.openshift.io\" denied the request: Denied. Err Managed OpenShift customers may only remove the following protected labels from Namespaces: ([openshift.io/cluster-monitoring])"}
```

After updating the test cluster's webhooks with these changes, the error was no longer reported by the operator.