### PR TITLE
[SREP-1546] prevent accidental deletions of HCP cluster resources

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -870,6 +870,134 @@ objects:
   spec:
     clusterDeploymentSelector:
       matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      matchLabels:
+        api.openshift.com/managed: "true"
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        name: sre-hcpnamespace-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /hcpnamespace-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: hcpnamespace-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - ""
+          apiVersions:
+          - '*'
+          operations:
+          - DELETE
+          resources:
+          - namespaces
+          scope: Cluster
+        sideEffects: None
+        timeoutSeconds: 2
+  status: {}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: "true"
+    name: managed-cluster-validating-webhooks-3
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      matchLabels:
+        api.openshift.com/managed: "true"
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        name: sre-hostedcluster-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /hostedcluster-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: hostedcluster-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - hypershift.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - DELETE
+          resources:
+          - hostedclusters
+          scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 2
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        name: sre-hostedcontrolplane-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /hostedcontrolplane-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: hostedcontrolplane-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - hypershift.openshift.io
+          apiVersions:
+          - '*'
+          operations:
+          - DELETE
+          resources:
+          - hostedcontrolplanes
+          scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 2
+  status: {}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: "true"
+    name: managed-cluster-validating-webhooks-4
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
       - key: ext-managed.openshift.io/legacy-ingress-support
         operator: In
         values:
@@ -909,6 +1037,55 @@ objects:
           scope: Namespaced
         sideEffects: None
         timeoutSeconds: 1
+  status: {}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: "true"
+    name: managed-cluster-validating-webhooks-5
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      matchLabels:
+        api.openshift.com/managed: "true"
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        annotations:
+          service.beta.openshift.io/inject-cabundle: "true"
+        name: sre-manifestworks-validation
+      webhooks:
+      - admissionReviewVersions:
+        - v1
+        clientConfig:
+          service:
+            name: validation-webhook
+            namespace: openshift-validation-webhook
+            path: /manifestworks-validation
+        failurePolicy: Ignore
+        matchPolicy: Equivalent
+        name: manifestworks-validation.managed.openshift.io
+        rules:
+        - apiGroups:
+          - work.open-cluster-management.io
+          apiVersions:
+          - '*'
+          operations:
+          - DELETE
+          resources:
+          - manifestworks
+          scope: Namespaced
+        sideEffects: None
+        timeoutSeconds: 2
   status: {}
 parameters:
 - name: IMAGE_TAG

--- a/pkg/webhooks/add_hcpnamespace.go
+++ b/pkg/webhooks/add_hcpnamespace.go
@@ -1,0 +1,7 @@
+package webhooks
+
+import webhooks "github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/hcpnamespace"
+
+func init() {
+	Register(webhooks.WebhookName, func() Webhook { return webhooks.NewWebhook() })
+}

--- a/pkg/webhooks/add_hostedcluster.go
+++ b/pkg/webhooks/add_hostedcluster.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/hostedcluster"
+)
+
+func init() {
+	Register(hostedcluster.WebhookName, func() Webhook { return hostedcluster.NewWebhook() })
+}

--- a/pkg/webhooks/add_hostedcontrolplane.go
+++ b/pkg/webhooks/add_hostedcontrolplane.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/hostedcontrolplane"
+)
+
+func init() {
+	Register(hostedcontrolplane.WebhookName, func() Webhook { return hostedcontrolplane.NewWebhook() })
+}

--- a/pkg/webhooks/add_manifestworks.go
+++ b/pkg/webhooks/add_manifestworks.go
@@ -1,0 +1,9 @@
+package webhooks
+
+import (
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/manifestworks"
+)
+
+func init() {
+	Register(manifestworks.WebhookName, func() Webhook { return manifestworks.NewWebhook() })
+}

--- a/pkg/webhooks/hcpnamespace/hcpnamespace.go
+++ b/pkg/webhooks/hcpnamespace/hcpnamespace.go
@@ -1,0 +1,200 @@
+package hcpnamespace
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"slices"
+	"sync"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName string = "hcpnamespace-validation"
+	docString   string = "Validates HCP namespace deletion operations are only performed by authorized service accounts"
+)
+
+var (
+	allowedUsers = []string{
+		"system:admin",
+		"system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+		"system:serviceaccount:open-cluster-management-agent:klusterlet",
+		"system:serviceaccount:hypershift:operator",
+	}
+
+	// Protected namespace patterns
+	protectedNamespacePatterns = []string{
+		"^ocm-staging-.*",
+		"^ocm-production-.*",
+		"^ocm-integration-.*",
+		"^klusterlet-.*",
+		"^hs-mc-.*",
+	}
+
+	protectedNamespaceRegexps = compileRegexps(protectedNamespacePatterns)
+
+	scope = admissionregv1.ClusterScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{""},
+				APIVersions: []string{"*"},
+				Resources:   []string{"namespaces"},
+				Scope:       &scope,
+			},
+		},
+	}
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+)
+
+func compileRegexps(patterns []string) []*regexp.Regexp {
+	regexps := make([]*regexp.Regexp, len(patterns))
+	for i, pattern := range patterns {
+		regexps[i] = regexp.MustCompile(pattern)
+	}
+	return regexps
+}
+
+// HCPNamespaceWebhook validates HCP namespace deletion operations
+type HCPNamespaceWebhook struct {
+	mu sync.Mutex
+	s  runtime.Scheme
+}
+
+// ObjectSelector implements Webhook interface
+func (s *HCPNamespaceWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
+func (s *HCPNamespaceWebhook) Doc() string {
+	return docString
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *HCPNamespaceWebhook) TimeoutSeconds() int32 { return 2 }
+
+// MatchPolicy implements Webhook interface
+func (s *HCPNamespaceWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Name implements Webhook interface
+func (s *HCPNamespaceWebhook) Name() string { return WebhookName }
+
+// FailurePolicy implements Webhook interface
+func (s *HCPNamespaceWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// Rules implements Webhook interface
+func (s *HCPNamespaceWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// GetURI implements Webhook interface
+func (s *HCPNamespaceWebhook) GetURI() string { return "/hcpnamespace-validation" }
+
+// SideEffects implements Webhook interface
+func (s *HCPNamespaceWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// Validate - Make sure we're working with a well-formed Admission Request object
+func (s *HCPNamespaceWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "Namespace")
+
+	return valid
+}
+
+// isProtectedNamespace checks if the namespace matches any of the protected patterns
+func isProtectedNamespace(namespaceName string) bool {
+	for _, re := range protectedNamespaceRegexps {
+		if re.MatchString(namespaceName) {
+			return true
+		}
+	}
+	return false
+}
+
+// Authorized implements Webhook interface
+func (s *HCPNamespaceWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+// Is the request authorized
+func (s *HCPNamespaceWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	// Allow authorized users/service accounts
+	if slices.Contains(allowedUsers, request.UserInfo.Username) {
+		ret = admissionctl.Allowed("User/ServiceAccount is authorized to delete HCP namespaces")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// Check if the namespace is protected
+	namespace := request.Name
+	if !isProtectedNamespace(namespace) {
+		// If the namespace doesn't match protected patterns, allow the operation
+		ret = admissionctl.Allowed("Namespace is not protected")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// If not a delete operation, allow it
+	if request.Operation != admissionv1.Delete {
+		ret = admissionctl.Allowed("Only DELETE operations are restricted")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// If we get here, the namespace is protected and the user is not authorized
+	log.Info("Unauthorized attempt to delete protected namespace",
+		"user", request.UserInfo.Username,
+		"namespace", namespace,
+		"groups", request.UserInfo.Groups)
+
+	ret = admissionctl.Denied(fmt.Sprintf("Only authorized users/service accounts can delete this namespace %s", namespace))
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+func (s *HCPNamespaceWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	customLabelSelector := utils.DefaultLabelSelector()
+	customLabelSelector.MatchExpressions = append(customLabelSelector.MatchExpressions,
+		metav1.LabelSelectorRequirement{
+			Key:      "ext-hypershift.openshift.io/cluster-type",
+			Operator: metav1.LabelSelectorOpIn,
+			Values: []string{
+				"management-cluster",
+				"service-cluster",
+			},
+		})
+	return customLabelSelector
+}
+
+func (s *HCPNamespaceWebhook) ClassicEnabled() bool { return true }
+
+func (s *HCPNamespaceWebhook) HypershiftEnabled() bool { return false }
+
+// NewWebhook creates a new webhook
+func NewWebhook() *HCPNamespaceWebhook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to HCPNamespaceWebhook")
+		os.Exit(1)
+	}
+
+	return &HCPNamespaceWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/hcpnamespace/hcpnamespace_test.go
+++ b/pkg/webhooks/hcpnamespace/hcpnamespace_test.go
@@ -1,0 +1,75 @@
+package hcpnamespace
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestAuthorized(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		namespace     string
+		operation     admissionv1.Operation
+		shouldBeValid bool
+	}{
+		{
+			name:          "Allowed user can delete protected namespace",
+			username:      "system:admin",
+			namespace:     "ocm-staging-test",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Klusterlet SA can delete protected namespace",
+			username:      "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+			namespace:     "klusterlet-test",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Hypershift operator can delete protected namespace",
+			username:      "system:serviceaccount:hypershift:operator",
+			namespace:     "hs-mc-test",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Random user cannot delete protected namespace",
+			username:      "unknown-user",
+			namespace:     "ocm-staging-test",
+			operation:     admissionv1.Delete,
+			shouldBeValid: false,
+		},
+		{
+			name:          "Random user can delete unprotected namespace",
+			username:      "unknown-user",
+			namespace:     "test-namespace",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			webhook := NewWebhook()
+			request := admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: test.namespace,
+					UserInfo: authenticationv1.UserInfo{
+						Username: test.username,
+					},
+					Operation: test.operation,
+				},
+			}
+
+			response := webhook.Authorized(request)
+			if response.Allowed != test.shouldBeValid {
+				t.Errorf("Unexpected response. Got %v, expected %v", response.Allowed, test.shouldBeValid)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/hostedcluster/hostedcluster.go
+++ b/pkg/webhooks/hostedcluster/hostedcluster.go
@@ -1,0 +1,152 @@
+package hostedcluster
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName string = "hostedcluster-validation"
+	docString   string = "Validates HostedCluster deletion operations are only performed by authorized service accounts"
+)
+
+var (
+	// Only this service account is allowed to delete HostedClusters
+	allowedServiceAccount = "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa"
+
+	scope = admissionregv1.NamespacedScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"hypershift.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"hostedclusters"},
+				Scope:       &scope,
+			},
+		},
+	}
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+)
+
+// HostedClusterWebhook validates HostedCluster deletion operations
+type HostedClusterWebhook struct {
+	mu sync.Mutex
+	s  runtime.Scheme
+}
+
+// ObjectSelector implements Webhook interface
+func (s *HostedClusterWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
+func (s *HostedClusterWebhook) Doc() string {
+	return fmt.Sprintf(docString)
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *HostedClusterWebhook) TimeoutSeconds() int32 { return 2 }
+
+// MatchPolicy implements Webhook interface
+func (s *HostedClusterWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Name implements Webhook interface
+func (s *HostedClusterWebhook) Name() string { return WebhookName }
+
+// FailurePolicy implements Webhook interface
+func (s *HostedClusterWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// Rules implements Webhook interface
+func (s *HostedClusterWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// GetURI implements Webhook interface
+func (s *HostedClusterWebhook) GetURI() string { return "/hostedcluster-validation" }
+
+// SideEffects implements Webhook interface
+func (s *HostedClusterWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// Validate - Make sure we're working with a well-formed Admission Request object
+func (s *HostedClusterWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "HostedCluster")
+	valid = valid && (req.Kind.Group == "hypershift.openshift.io")
+
+	return valid
+}
+
+// Authorized implements Webhook interface
+func (s *HostedClusterWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+// Is the request authorized
+func (s *HostedClusterWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	// Only allow DELETE operations from the specified service account
+	if request.UserInfo.Username == allowedServiceAccount {
+		ret = admissionctl.Allowed("Service account is authorized to delete HostedCluster resources")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// If not a delete operation, allow it
+	if request.Operation != admissionv1.Delete {
+		ret = admissionctl.Allowed("Only DELETE operations are restricted")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// Deny all other requests
+	log.Info("Unauthorized attempt to delete HostedCluster",
+		"user", request.UserInfo.Username,
+		"groups", request.UserInfo.Groups)
+
+	ret = admissionctl.Denied(fmt.Sprintf("Only %s is authorized to delete HostedCluster resources", allowedServiceAccount))
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+func (s *HostedClusterWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	customLabelSelector := utils.DefaultLabelSelector()
+	customLabelSelector.MatchExpressions = append(customLabelSelector.MatchExpressions,
+		metav1.LabelSelectorRequirement{
+			Key:      "ext-hypershift.openshift.io/cluster-type",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"management-cluster"},
+		})
+	return customLabelSelector
+}
+
+func (s *HostedClusterWebhook) ClassicEnabled() bool { return true }
+
+func (s *HostedClusterWebhook) HypershiftEnabled() bool { return false }
+
+// NewWebhook creates a new webhook
+func NewWebhook() *HostedClusterWebhook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to HostedClusterWebhook")
+		os.Exit(1)
+	}
+	return &HostedClusterWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/hostedcluster/hostedcluster_test.go
+++ b/pkg/webhooks/hostedcluster/hostedcluster_test.go
@@ -1,0 +1,55 @@
+package hostedcluster
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestHostedClusterAuthorized(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		operation     admissionv1.Operation
+		shouldBeValid bool
+	}{
+		{
+			name:          "Allowed service account can delete hostedcluster",
+			username:      "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Random user cannot delete hostedcluster",
+			username:      "unknown-user",
+			operation:     admissionv1.Delete,
+			shouldBeValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			webhook := NewWebhook()
+			request := admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: test.username,
+					},
+					Operation: test.operation,
+					Kind: metav1.GroupVersionKind{
+						Group: "hypershift.openshift.io",
+						Kind:  "HostedCluster",
+					},
+				},
+			}
+
+			response := webhook.Authorized(request)
+			if response.Allowed != test.shouldBeValid {
+				t.Errorf("Unexpected response for %s. Got %v, expected %v", test.name, response.Allowed, test.shouldBeValid)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/hostedcontrolplane/hostedcontrolplane.go
+++ b/pkg/webhooks/hostedcontrolplane/hostedcontrolplane.go
@@ -1,0 +1,158 @@
+package hostedcontrolplane
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName string = "hostedcontrolplane-validation"
+	docString   string = "Validates HostedControlPlane deletion operations are only performed by authorized service accounts"
+)
+
+var (
+	// Service accounts allowed to delete HostedControlPlanes
+	allowedServiceAccounts = []string{
+		"system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+	}
+
+	scope = admissionregv1.NamespacedScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"hypershift.openshift.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"hostedcontrolplanes"},
+				Scope:       &scope,
+			},
+		},
+	}
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+)
+
+// HostedControlPlaneWebhook validates HostedControlPlane deletion operations
+type HostedControlPlaneWebhook struct {
+	mu sync.Mutex
+	s  runtime.Scheme
+}
+
+// ObjectSelector implements Webhook interface
+func (s *HostedControlPlaneWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
+func (s *HostedControlPlaneWebhook) Doc() string {
+	return fmt.Sprintf(docString)
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *HostedControlPlaneWebhook) TimeoutSeconds() int32 { return 2 }
+
+// MatchPolicy implements Webhook interface
+func (s *HostedControlPlaneWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Name implements Webhook interface
+func (s *HostedControlPlaneWebhook) Name() string { return WebhookName }
+
+// FailurePolicy implements Webhook interface
+func (s *HostedControlPlaneWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// Rules implements Webhook interface
+func (s *HostedControlPlaneWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// GetURI implements Webhook interface
+func (s *HostedControlPlaneWebhook) GetURI() string { return "/hostedcontrolplane-validation" }
+
+// SideEffects implements Webhook interface
+func (s *HostedControlPlaneWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// Validate - Make sure we're working with a well-formed Admission Request object
+func (s *HostedControlPlaneWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "HostedControlPlane")
+	valid = valid && (req.Kind.Group == "hypershift.openshift.io")
+
+	return valid
+}
+
+// Authorized implements Webhook interface
+func (s *HostedControlPlaneWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+// Is the request authorized?
+func (s *HostedControlPlaneWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	// Allow authorized service accounts
+	for _, sa := range allowedServiceAccounts {
+		if request.UserInfo.Username == sa {
+			ret = admissionctl.Allowed("Service account is authorized to delete HostedControlPlane resources")
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
+	}
+
+	// If not a delete operation, allow it
+	if request.Operation != admissionv1.Delete {
+		ret = admissionctl.Allowed("Only DELETE operations are restricted")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// Deny all other delete attempts
+	log.Info("Unauthorized attempt to delete HostedControlPlane",
+		"user", request.UserInfo.Username,
+		"groups", request.UserInfo.Groups)
+
+	ret = admissionctl.Denied(fmt.Sprintf("Only authorized service accounts %s can delete HostedControlPlane resources", strings.Join(allowedServiceAccounts, ", ")))
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+func (s *HostedControlPlaneWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	customLabelSelector := utils.DefaultLabelSelector()
+	customLabelSelector.MatchExpressions = append(customLabelSelector.MatchExpressions,
+		metav1.LabelSelectorRequirement{
+			Key:      "ext-hypershift.openshift.io/cluster-type",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"management-cluster"},
+		})
+	return customLabelSelector
+}
+
+func (s *HostedControlPlaneWebhook) ClassicEnabled() bool { return true }
+
+func (s *HostedControlPlaneWebhook) HypershiftEnabled() bool { return false }
+
+// NewWebhook creates a new webhook
+func NewWebhook() *HostedControlPlaneWebhook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to HostedControlPlaneWebhook")
+		os.Exit(1)
+	}
+	return &HostedControlPlaneWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/hostedcontrolplane/hostedcontrolplane_test.go
+++ b/pkg/webhooks/hostedcontrolplane/hostedcontrolplane_test.go
@@ -1,0 +1,55 @@
+package hostedcontrolplane
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestHostedControlPlaneAuthorized(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		operation     admissionv1.Operation
+		shouldBeValid bool
+	}{
+		{
+			name:          "Allowed service account can delete hostedcontrolplane",
+			username:      "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Random user cannot delete hostedcontrolplane",
+			username:      "unknown-user",
+			operation:     admissionv1.Delete,
+			shouldBeValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			webhook := NewWebhook()
+			request := admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: test.username,
+					},
+					Operation: test.operation,
+					Kind: metav1.GroupVersionKind{
+						Group: "hypershift.openshift.io",
+						Kind:  "HostedControlPlane",
+					},
+				},
+			}
+
+			response := webhook.Authorized(request)
+			if response.Allowed != test.shouldBeValid {
+				t.Errorf("Unexpected response for %s. Got %v, expected %v", test.name, response.Allowed, test.shouldBeValid)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/manifestworks/manifestworks.go
+++ b/pkg/webhooks/manifestworks/manifestworks.go
@@ -1,0 +1,157 @@
+package manifestworks
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"sync"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	WebhookName string = "manifestworks-validation"
+	docString   string = "Validates ManifestWorks deletion operations are only performed by authorized service accounts"
+)
+
+var (
+	// List of service accounts allowed to delete ManifestWorks
+	allowedServiceAccounts = []string{
+		"system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+		"system:serviceaccount:open-cluster-management-agent:klusterlet",
+		"system:serviceaccount:hypershift:operator",
+	}
+
+	scope = admissionregv1.NamespacedScope
+	rules = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{"DELETE"},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"work.open-cluster-management.io"},
+				APIVersions: []string{"*"},
+				Resources:   []string{"manifestworks"},
+				Scope:       &scope,
+			},
+		},
+	}
+	timeout int32 = 2
+	log           = logf.Log.WithName(WebhookName)
+)
+
+// ManifestWorksWebhook validates ManifestWorks deletion operations
+type ManifestWorksWebhook struct {
+	mu sync.Mutex
+	s  runtime.Scheme
+}
+
+// ObjectSelector implements Webhook interface
+func (s *ManifestWorksWebhook) ObjectSelector() *metav1.LabelSelector { return nil }
+
+func (s *ManifestWorksWebhook) Doc() string {
+	return fmt.Sprintf(docString)
+}
+
+// TimeoutSeconds implements Webhook interface
+func (s *ManifestWorksWebhook) TimeoutSeconds() int32 { return 2 }
+
+// MatchPolicy implements Webhook interface
+func (s *ManifestWorksWebhook) MatchPolicy() admissionregv1.MatchPolicyType {
+	return admissionregv1.Equivalent
+}
+
+// Name implements Webhook interface
+func (s *ManifestWorksWebhook) Name() string { return WebhookName }
+
+// FailurePolicy implements Webhook interface
+func (s *ManifestWorksWebhook) FailurePolicy() admissionregv1.FailurePolicyType {
+	return admissionregv1.Ignore
+}
+
+// Rules implements Webhook interface
+func (s *ManifestWorksWebhook) Rules() []admissionregv1.RuleWithOperations { return rules }
+
+// GetURI implements Webhook interface
+func (s *ManifestWorksWebhook) GetURI() string { return "/manifestworks-validation" }
+
+// SideEffects implements Webhook interface
+func (s *ManifestWorksWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+
+// Validate - Make sure we're working with a well-formed Admission Request object
+func (s *ManifestWorksWebhook) Validate(req admissionctl.Request) bool {
+	valid := true
+	valid = valid && (req.UserInfo.Username != "")
+	valid = valid && (req.Kind.Kind == "ManifestWork")
+	valid = valid && (req.Kind.Group == "work.open-cluster-management.io")
+
+	return valid
+}
+
+// Authorized implements Webhook interface
+func (s *ManifestWorksWebhook) Authorized(request admissionctl.Request) admissionctl.Response {
+	return s.authorized(request)
+}
+
+// Is the request authorized?
+func (s *ManifestWorksWebhook) authorized(request admissionctl.Request) admissionctl.Response {
+	var ret admissionctl.Response
+
+	// Check if the requesting user is in the list of allowed service accounts
+	if slices.Contains(allowedServiceAccounts, request.UserInfo.Username) {
+		ret = admissionctl.Allowed("Service account is authorized to delete ManifestWork resources")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// If not a delete operation, allow it
+	if request.Operation != admissionv1.Delete {
+		ret = admissionctl.Allowed("Only DELETE operations are restricted")
+		ret.UID = request.AdmissionRequest.UID
+		return ret
+	}
+
+	// Deny all other requests
+	log.Info("Unauthorized attempt to delete ManifestWork",
+		"user", request.UserInfo.Username,
+		"groups", request.UserInfo.Groups)
+
+	ret = admissionctl.Denied(fmt.Sprintf("Only authorized service accounts can delete ManifestWork resources. Allowed service accounts: %v", allowedServiceAccounts))
+	ret.UID = request.AdmissionRequest.UID
+	return ret
+}
+
+// SyncSetLabelSelector returns the label selector to use in the SyncSet.
+func (s *ManifestWorksWebhook) SyncSetLabelSelector() metav1.LabelSelector {
+	customLabelSelector := utils.DefaultLabelSelector()
+	customLabelSelector.MatchExpressions = append(customLabelSelector.MatchExpressions,
+		metav1.LabelSelectorRequirement{
+			Key:      "ext-hypershift.openshift.io/cluster-type",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"service-cluster"},
+		})
+	return customLabelSelector
+}
+
+func (s *ManifestWorksWebhook) ClassicEnabled() bool { return true }
+
+func (s *ManifestWorksWebhook) HypershiftEnabled() bool { return false }
+
+// NewWebhook creates a new webhook
+func NewWebhook() *ManifestWorksWebhook {
+	scheme := runtime.NewScheme()
+	err := admissionv1.AddToScheme(scheme)
+	if err != nil {
+		log.Error(err, "Fail adding admissionsv1 scheme to ManifestWorksWebhook")
+		os.Exit(1)
+	}
+	return &ManifestWorksWebhook{
+		s: *scheme,
+	}
+}

--- a/pkg/webhooks/manifestworks/manifestworks_test.go
+++ b/pkg/webhooks/manifestworks/manifestworks_test.go
@@ -1,0 +1,67 @@
+package manifestworks
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestManifestWorksAuthorized(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		operation     admissionv1.Operation
+		shouldBeValid bool
+	}{
+		{
+			name:          "Klusterlet work SA can delete manifestworks",
+			username:      "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Klusterlet SA can delete manifestworks",
+			username:      "system:serviceaccount:open-cluster-management-agent:klusterlet",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Hypershift operator can delete manifestworks",
+			username:      "system:serviceaccount:hypershift:operator",
+			operation:     admissionv1.Delete,
+			shouldBeValid: true,
+		},
+		{
+			name:          "Random user cannot delete manifestworks",
+			username:      "unknown-user",
+			operation:     admissionv1.Delete,
+			shouldBeValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			webhook := NewWebhook()
+			request := admissionctl.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UserInfo: authenticationv1.UserInfo{
+						Username: test.username,
+					},
+					Operation: test.operation,
+					Kind: metav1.GroupVersionKind{
+						Group: "work.open-cluster-management.io",
+						Kind:  "ManifestWork",
+					},
+				},
+			}
+
+			response := webhook.Authorized(request)
+			if response.Allowed != test.shouldBeValid {
+				t.Errorf("Unexpected response for %s. Got %v, expected %v", test.name, response.Allowed, test.shouldBeValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?

This PR adds 4 additional webhooks to prevent accidental deletion of HCP resorces. The following resources are protected deletions:

- HostedCluster (on mc)
- HostedControlPlane (on mc)
- ManifestWork (on SC)
- ocm-production-* namespaces (on mc)
- hs-mc-* namespaces (on mc and sc)

Additional webhook list:
- hostedcluster-validation
- hostedcontrolplane-validation
- manifestworks-validation
- hcpnamespace-validation

### Which Jira/Github issue(s) this PR fixes?
- https://issues.redhat.com/browse/SREP-1546
- https://issues.redhat.com/browse/SREP-1547

