### PR TITLE
SREP-4236: Fix GOFLAGS and regenerate package resources

### DIFF
--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -227,6 +227,36 @@ webhooks:
   timeoutSeconds: 2
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    package-operator.run/phase: webhooks
+    service.beta.openshift.io/inject-cabundle: "false"
+  name: sre-network-operator-validation
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '{{.config.serviceca | b64enc }}'
+    url: https://validation-webhook.{{.package.metadata.namespace}}.svc.cluster.local/network-operator-validation
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: network-operator-validation.managed.openshift.io
+  rules:
+  - apiGroups:
+    - operator.openshift.io
+    apiVersions:
+    - '*'
+    operations:
+    - UPDATE
+    resources:
+    - network
+    - networks
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 2
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:

--- a/hack/prow_pr_check.sh
+++ b/hack/prow_pr_check.sh
@@ -9,6 +9,10 @@ echo "Using go version $(go version)"
 
 cd "${REPO_ROOT}"
 
+# Prow may set GOFLAGS=-mod=vendor which breaks us since we use modules
+unset GOFLAGS
+export GOFLAGS=-mod=mod
+
 # Run tests
 make test
 


### PR DESCRIPTION
## Summary
- Sets `GOFLAGS=-mod=mod` in `hack/prow_pr_check.sh` to fix Prow pr-check failure
- Regenerates stale `config/package/resources.yaml.gotmpl` to include `sre-network-operator-validation` webhook

## Context
The Prow environment sets `GOFLAGS=-mod=vendor` by default, which conflicts with this repo's module-based setup. The Makefile already handles this with `unexport GOFLAGS` (line 29), but the new `prow_pr_check.sh` script was missing the equivalent.

Fixes the pr-check failure in [openshift/release#77097](https://github.com/openshift/release/pull/77097).

## Test plan
- [x] Verified locally: `GOFLAGS=-mod=vendor bash hack/prow_pr_check.sh` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)