### PR TITLE
DO NOT MERGE: Test pr-check catches resource drift

### DIFF
--- a/pkg/webhooks/scc/scc.go
+++ b/pkg/webhooks/scc/scc.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	timeout int32 = 2
+	timeout int32 = 3
 	log           = logf.Log.WithName(WebhookName)
 	scope         = admissionregv1.ClusterScope
 	rules         = []admissionregv1.RuleWithOperations{


### PR DESCRIPTION
Test PR to verify the new Prow pr-check job catches stale generated resources.

This changes the SCC webhook timeout without regenerating syncset/package resources. The pr-check should fail with "unexpected changes after building".

Will be closed after verification.