### PR TITLE
SREP-4349: Updated base image and go version to fix CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25.7-1774351791
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25.8-1776763740
 FROM ${BASE_IMAGE} AS builder
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
This PR addresses multiple CVEs that exist in the base image:

```
Before:
7 High/Critical stdlib CVEs (due to Go 1.25.7 )
After:
6 High/Critical stdlib CVE (in Go 1.25.8)
1 CVEs fixed! 
Remaining CVE:
Requires Go 1.25.9 or 1.26.2 (not yet available)
```

```
grype registry.access.redhat.com/ubi9/go-toolset:1.25.7-1774351791 | grep -E "High|Critical" | grep stdlib
 ✔ Parsed image                    sha256:15708cf33bb77fd04071de23c38750cadf541132  
 ✔ Cataloged contents              7f4d4708bb41f24b2589a76aea8d2b359c9079b4c18c8fb  
   ├── ✔ Packages                        [666 packages]  
   ├── ✔ Executables                     [1,283 executables]  
   ├── ✔ File metadata                   [21,664 locations]  
   └── ✔ File digests                    [21,664 files]  
 ✔ Scanned for vulnerabilities     [1276 vulnerability matches]  
   ├── by severity: 10 critical, 187 high, 2248 medium, 1655 low, 16 negligible (18 
   └── by status:   236 fixed, 3898 not-fixed, 2858 ignored 
stdlib                       go1.25.7                                            *1.25.8, 1.26.1                            go-module  CVE-2026-25679       High        < 0.1% (15th)  < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2                            go-module  CVE-2026-27143       Critical    < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2                            go-module  CVE-2026-32281       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2                            go-module  CVE-2026-32280       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2                            go-module  CVE-2026-32283       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2                            go-module  CVE-2026-27140       High        < 0.1% (2nd)   < 0.1  
A newer version of grype is available for download: 0.111.1 (installed version is 0.111.0)
stdlib                       go1.25.7                                            *1.25.9, 1.26.2                            go-module  CVE-2026-27144       High        < 0.1% (0th)   < 0.1  

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->