### PR TITLE
SREP-4349: Update base image to fix CVEs 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25.8-1776763740
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25.9-1777043046
 FROM ${BASE_IMAGE} AS builder
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
This PR addresses multiple CVEs that exist in the base image: 

Before:
13 High/Critical stdlib CVEs (due to Go 1.25.7 and 1.25.8 )
After:
7 High/Critical stdlib CVE (in Go 1.25.8)
6 CVEs fixed! 
Remaining CVE:
Requires 1.26.1 or 1.26.2 (not yet available)

```
grype registry.access.redhat.com/ubi9/go-toolset:1.25.8-1776763740 | grep -E "Critical|High" | grep stdlib
 ✔ Parsed image                                                   sha256:dfd27e15435fa1aa8cddba53a4a743fb1686b8e489e1c61aaf33b1ceed94b594 
 ✔ Cataloged contents                                                    21c32020867e17a72931dd04ec72e16193ed1549352cfb9dc72c0a6e35d4fa7b 
   ├── ✔ Packages                        [651 packages]  
   ├── ✔ Executables                     [1,283 executables]  
   ├── ✔ File metadata                   [21,387 locations]  
   └── ✔ File digests                    [21,387 files]  
 ✔ Scanned for vulnerabilities     [1192 vulnerability matches]  
   ├── by severity: 10 critical, 132 high, 2321 medium, 1658 low, 16 negligible (18 unknown)
   └── by status:   96 fixed, 4059 not-fixed, 2963 ignored 
A newer version of grype is available for download: 0.111.1 (installed version is 0.111.0)
stdlib                       go1.25.7                                            *1.25.8, 1.26.1  go-module  CVE-2026-25679       High        < 0.1% (16th)  < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2  go-module  CVE-2026-27143       Critical    < 0.1% (4th)   < 0.1  
stdlib                       go1.25.8                                            *1.25.9, 1.26.2  go-module  CVE-2026-27143       Critical    < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2  go-module  CVE-2026-32281       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.8                                            *1.25.9, 1.26.2  go-module  CVE-2026-32281       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2  go-module  CVE-2026-32280       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.8                                            *1.25.9, 1.26.2  go-module  CVE-2026-32280       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2  go-module  CVE-2026-32283       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.8                                            *1.25.9, 1.26.2  go-module  CVE-2026-32283       High        < 0.1% (4th)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2  go-module  CVE-2026-27140       High        < 0.1% (2nd)   < 0.1  
stdlib                       go1.25.8                                            *1.25.9, 1.26.2  go-module  CVE-2026-27140       High        < 0.1% (2nd)   < 0.1  
stdlib                       go1.25.7                                            *1.25.9, 1.26.2  go-module  CVE-2026-27144       High        < 0.1% (0th)   < 0.1  
stdlib                       go1.25.8                                            *1.25.9, 1.26.2  go-module  CVE-2026-27144       High        < 0.1% (0th)   < 0.1  

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build environment to the latest Go toolchain version for improved build stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->