### PR TITLE
Fix e2e rate limiter timeout in namespace permission probe

### DIFF
--- a/test/e2e/validation_webhook_tests.go
+++ b/test/e2e/validation_webhook_tests.go
@@ -69,18 +69,19 @@ var _ = Describe("Managed Cluster Validating Webhooks", Ordered, func() {
 
 		By("waiting for namespace permissions to be ready")
 		probe := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ns-ready-probe", Namespace: ns}}
-		ctx, cancel := context.WithTimeout(context.TODO(), 120*time.Second)
-		defer cancel()
+		deadline := time.Now().Add(120 * time.Second)
 		for {
-			createErr := dedicatedAdmink8s.Create(ctx, probe)
+			attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			createErr := dedicatedAdmink8s.Create(attemptCtx, probe)
+			attemptCancel()
 			if createErr == nil {
-				_ = dedicatedAdmink8s.Delete(context.TODO(), probe)
+				_ = dedicatedAdmink8s.Delete(context.Background(), probe)
 				break
 			}
-			if ctx.Err() != nil {
+			if time.Now().After(deadline) {
 				Expect(createErr).ShouldNot(HaveOccurred(), "Timed out waiting for namespace permissions")
 			}
-			if !errors.IsForbidden(createErr) {
+			if !errors.IsForbidden(createErr) && !strings.Contains(createErr.Error(), "context deadline exceeded") {
 				Expect(createErr).ShouldNot(HaveOccurred(), "Unexpected error probing namespace readiness")
 			}
 			time.Sleep(2 * time.Second)


### PR DESCRIPTION
## Summary

- Fix `sre-regular-user-validation` e2e test failing with `client rate limiter Wait returned an error: context deadline exceeded`
- The `createNS` helper passed a shared 120s context to every `Create` call in the retry loop. When the client rate limiter was exhausted, `Create` blocked in `ratelimiter.Wait(ctx)` until the context expired
- Use a per-attempt 10s context so each `Create` call fails fast and retries, instead of blocking on the rate limiter for the full timeout

## Test plan

- [ ] Verify MCVW e2e test passes on integration after merge
- [ ] Verify auto-promotion pipeline unblocks for SSS STAGE targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation webhook test reliability with enhanced timeout and error handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->