### PR TITLE
fix: reduce the log for allowed authorization

### DIFF
--- a/pkg/webhooks/customresourcedefinitions/customresourcedefinitions.go
+++ b/pkg/webhooks/customresourcedefinitions/customresourcedefinitions.go
@@ -94,7 +94,6 @@ func (s *customresourcedefinitionsruleWebhook) authorized(request admissionctl.R
 		return ret
 	}
 
-	log.Info("Allowing access", "request", request.AdmissionRequest)
 	ret = admissionctl.Allowed("Non managed CustomResourceDefinition")
 	ret.UID = request.AdmissionRequest.UID
 	return ret

--- a/pkg/webhooks/networkpolicies/networkpolicies.go
+++ b/pkg/webhooks/networkpolicies/networkpolicies.go
@@ -104,7 +104,6 @@ func (s *networkpoliciesruleWebhook) authorized(request admissionctl.Request) ad
 		}
 	}
 
-	log.Info("Allowing access", "request", request.AdmissionRequest)
 	ret = admissionctl.Allowed("Non managed namespace")
 	ret.UID = request.AdmissionRequest.UID
 	return ret

--- a/pkg/webhooks/prometheusrule/prometheusrule.go
+++ b/pkg/webhooks/prometheusrule/prometheusrule.go
@@ -111,7 +111,6 @@ func (s *prometheusruleWebhook) authorized(request admissionctl.Request) admissi
 		return ret
 	}
 
-	log.Info("Allowing access")
 	ret = admissionctl.Allowed("Non managed namespace")
 	ret.UID = request.AdmissionRequest.UID
 	return ret

--- a/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade.go
+++ b/pkg/webhooks/techpreviewnoupgrade/techpreviewnoupgrade.go
@@ -124,8 +124,6 @@ func (s *TechPreviewNoUpgradeWebhook) authorized(request admissionctl.Request) a
 		return ret
 	}
 
-	log.Info("Allowing access", "request", request.AdmissionRequest)
-
 	ret = admissionctl.Allowed("FeatureGate operation is allowed")
 	ret.UID = request.AdmissionRequest.UID
 


### PR DESCRIPTION
Currently, the "Allowing access" logs is flooding the pod log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reduced log verbosity by removing informational entries for non-protected CustomResourceDefinition operations. Authorization behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->