### PR TITLE
allow the delete any service account in default ns

### DIFF
--- a/pkg/webhooks/serviceaccount/serviceaccount.go
+++ b/pkg/webhooks/serviceaccount/serviceaccount.go
@@ -51,6 +51,7 @@ var (
 		"deployer",
 	}
 	exceptionNamespaces = []string{
+		"default",
 		"openshift-logging",
 		"openshift-user-workload-monitoring",
 		"openshift-operators",


### PR DESCRIPTION
We allow the serviceaccount `default` `builder` and `deployer` to be deleted in all the namespaces.

But in default namespace, there are only those 3 accounts exist from the beginning. That means every other SA in default ns should be owned by user or other operator. It does not make sense to prevent them to be deleted by user.