### PR TITLE
Allow machineconfig webhooks to cluster admins

### DIFF
--- a/pkg/webhooks/regularuser/common/regularuser.go
+++ b/pkg/webhooks/regularuser/common/regularuser.go
@@ -27,16 +27,19 @@ import (
 // in the 'osd' package.
 
 const (
-	WebhookName         = "regular-user-validation"
-	docString           = `Managed OpenShift customers may not manage any objects in the following APIGroups %s, nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects.`
-	mustGatherKind      = "MustGather"
-	mustGatherGroup     = "managed.openshift.io"
-	clusterVersionKind  = "ClusterVersion"
-	clusterVersionGroup = "config.openshift.io"
-	customDomainKind    = "CustomDomain"
-	customDomainGroup   = "managed.openshift.io"
-	netNamespaceKind    = "NetNamespace"
-	netNamespaceGroup   = "network.openshift.io"
+	WebhookName           = "regular-user-validation"
+	docString             = `Managed OpenShift customers may not manage any objects in the following APIGroups %s, nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects.`
+	mustGatherKind        = "MustGather"
+	mustGatherGroup       = "managed.openshift.io"
+	clusterVersionKind    = "ClusterVersion"
+	clusterVersionGroup   = "config.openshift.io"
+	customDomainKind      = "CustomDomain"
+	customDomainGroup     = "managed.openshift.io"
+	netNamespaceKind      = "NetNamespace"
+	netNamespaceGroup     = "network.openshift.io"
+	machineConfigKind     = "MachineConfig"
+	machineConfigPoolKind = "MachineConfigPool"
+	machineConfigGroup    = "machineconfiguration.openshift.io"
 )
 
 var (
@@ -218,6 +221,16 @@ func (s *RegularuserWebhook) authorized(request admissionctl.Request) admissionc
 		return ret
 	}
 
+	// Check MachineConfig resources first - only cluster-admins group allowed
+	if request.Kind.Group == machineConfigGroup {
+		if isMachineConfigAuthorized(request) {
+			return utils.WebhookResponse(request, true, "")
+		} else {
+			log.Info("Denying access", "request", request.AdmissionRequest)
+			return utils.WebhookResponse(request, false, "Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support")
+		}
+	}
+
 	if strings.HasPrefix(request.AdmissionRequest.UserInfo.Username, "kube:") {
 		ret = admissionctl.Allowed("kube: users are allowed")
 		ret.UID = request.AdmissionRequest.UID
@@ -321,6 +334,21 @@ func isClusterVersionAuthorized(request admissionctl.Request) bool {
 	}
 
 	if strings.HasPrefix(request.AdmissionRequest.UserInfo.Username, "system:") && !strings.HasPrefix(request.AdmissionRequest.UserInfo.Username, "system:serviceaccount:") {
+		return true
+	}
+
+	return false
+}
+
+// isMachineConfigAuthorized allows cluster-admins group and backplane-cluster-admin user to modify MachineConfig resources
+func isMachineConfigAuthorized(request admissionctl.Request) bool {
+	// Allow cluster-admins group
+	if slices.Contains(request.UserInfo.Groups, "cluster-admins") {
+		return true
+	}
+
+	// Allow backplane-cluster-admin user
+	if slices.Contains(adminUsers, request.AdmissionRequest.UserInfo.Username) {
 		return true
 	}
 

--- a/pkg/webhooks/regularuser/common/regularuser_test.go
+++ b/pkg/webhooks/regularuser/common/regularuser_test.go
@@ -107,7 +107,6 @@ func runRegularuserTests(t *testing.T, tests []regularuserTests) {
 			t.Fatalf("%s No tracking UID associated with the response.", test.testID)
 		}
 	}
-	t.Skip()
 }
 
 // TestFirstBlock looks at the first block of permissions in the rules grouping.
@@ -194,7 +193,7 @@ func TestMachineConfig(t *testing.T) {
 			username:        "kube:system",
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
 			operation:       admissionv1.Create,
-			shouldBeAllowed: true,
+			shouldBeAllowed: false,
 		},
 		{
 			testID:          "machineconfig-clusteradmin-user",
@@ -205,7 +204,7 @@ func TestMachineConfig(t *testing.T) {
 			username:        "test-cluster-admin-user",
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth", "cluster-admins"},
 			operation:       admissionv1.Create,
-			shouldBeAllowed: false,
+			shouldBeAllowed: true,
 		},
 		{
 			testID:          "machineconfig-unpriv-user",
@@ -215,6 +214,28 @@ func TestMachineConfig(t *testing.T) {
 			targetGroup:     "machineconfiguration.openshift.io",
 			username:        "test-user",
 			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			testID:          "machineconfig-backplane-cluster-admin",
+			targetResource:  "machineconfigs",
+			targetKind:      "MachineConfig",
+			targetVersion:   "v1",
+			targetGroup:     "machineconfiguration.openshift.io",
+			username:        "backplane-cluster-admin",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			testID:          "machineconfig-srep-serviceaccount",
+			targetResource:  "machineconfigs",
+			targetKind:      "MachineConfig",
+			targetVersion:   "v1",
+			targetGroup:     "machineconfiguration.openshift.io",
+			username:        "system:serviceaccount:openshift-backplane-srep:test-sa",
+			userGroups:      []string{"system:authenticated", "system:serviceaccounts", "system:serviceaccounts:openshift-backplane-srep"},
 			operation:       admissionv1.Create,
 			shouldBeAllowed: false,
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation webhook now enforces access rules for MachineConfig requests and explicitly recognizes cluster-admins and a specific backplane-cluster-admin identity.

* **Bug Fixes**
  * Corrected authorization for MachineConfig so allowed/denied outcomes match intended access levels (service accounts like openshift-backplane-srep are denied).

* **Tests**
  * Test suite updated with new MachineConfig cases and no longer unconditionally skips at the end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->