### PR TITLE
OWNERS: remove Dee-6777 from srep-functional-team-thor

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -61,7 +61,6 @@ aliases:
     - feichashao
     - samanthajayasinghe
     - xiaoyu74
-    - Dee-6777
     - Tessg22
     - smarthall
   srep-infra-cicd:


### PR DESCRIPTION
Remove Dee-6777 from the `srep-functional-team-thor` alias in OWNERS_ALIASES.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team ownership records in OWNERS_ALIASES to reflect current functional team composition, ensuring code review assignments and authorization levels remain properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->