### PR TITLE
Remove abyrne55 from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@
 # =============================================================================
 aliases:
   srep-functional-team-aurora:
-    - abyrne55
     - dakotalongRH
     - joshbranham
     - luis-falcon
@@ -71,7 +70,6 @@ aliases:
     - jbpratt
     - yiqinzhang
   srep-functional-leads:
-    - abyrne55
     - clcollins
     - Nikokolas3270
     - theautoroboto


### PR DESCRIPTION
Removed myself from the srep-functional-team-aurora and srep-functional-leads aliases. Cheers y'all!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal team access configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->