### PR TITLE
[ROSAENG-963] fix: Prevent customer CREATE of ServiceAccounts in managed namespaces

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -801,6 +801,7 @@ objects:
           apiVersions:
           - v1
           operations:
+          - CREATE
           - DELETE
           resources:
           - serviceaccounts

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -479,6 +479,7 @@ webhooks:
     apiVersions:
     - v1
     operations:
+    - CREATE
     - DELETE
     resources:
     - serviceaccounts

--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -16,8 +16,20 @@
     "documentString": "Managed OpenShift Customers may not change CustomResourceDefinitions managed by Red Hat."
   },
   {
+    "webhookName": "hcpnamespace-validation",
+    "documentString": "Validates HCP namespace deletion operations are only performed by authorized service accounts"
+  },
+  {
     "webhookName": "hiveownership-validation",
     "documentString": "Managed OpenShift customers may not edit certain managed resources. A managed resource has a \"hive.openshift.io/managed\": \"true\" label."
+  },
+  {
+    "webhookName": "hostedcluster-validation",
+    "documentString": "Validates HostedCluster deletion operations are only performed by authorized service accounts"
+  },
+  {
+    "webhookName": "hostedcontrolplane-validation",
+    "documentString": "Validates HostedControlPlane deletion operations are only performed by authorized service accounts"
   },
   {
     "webhookName": "imagecontentpolicies-validation",
@@ -32,12 +44,16 @@
     "documentString": "Managed OpenShift Customer may create IngressControllers without necessary taints. This can cause those workloads to be provisioned on master nodes."
   },
   {
+    "webhookName": "manifestworks-validation",
+    "documentString": "Validates ManifestWorks deletion operations are only performed by authorized service accounts"
+  },
+  {
     "webhookName": "namespace-validation",
     "documentString": "Managed OpenShift Customers may not modify namespaces specified in the [openshift-monitoring/managed-namespaces openshift-monitoring/ocp-namespaces] ConfigMaps because customer workloads should be placed in customer-created namespaces. Customers may not create namespaces identified by this regular expression (^com$|^io$|^in$) because it could interfere with critical DNS resolution. Additionally, customers may not set or change the values of these Namespace labels [managed.openshift.io/storage-pv-quota-exempt managed.openshift.io/service-lb-quota-exempt]."
   },
   {
     "webhookName": "network-operator-validation",
-    "documentString": "Managed OpenShift customers may not modify critical fields in the network.operator CRD (such as spec.migration.networkType) because it can disrupt Cluster Network Operator operations and CNI migrations. Even cluster-admin users are blocked from modifying these critical fields."
+    "documentString": "Managed OpenShift customers may not modify critical fields in the network.operator CRD (such as spec.migration.networkType) because it can disrupt Cluster Network Operator operations and CNI migrations. Only backplane-cluster-admin, SRE, Cluster Network Operator (CNO), and Managed Upgrade Operator (MUO) service accounts are allowed to modify these critical fields. Regular cluster-admin users (system:admin) are explicitly blocked."
   },
   {
     "webhookName": "networkpolicies-validation",
@@ -61,7 +77,7 @@
   },
   {
     "webhookName": "regular-user-validation",
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [upgrade.managed.openshift.io config.openshift.io operator.openshift.io network.openshift.io admissionregistration.k8s.io addons.managed.openshift.io cloudingress.managed.openshift.io managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io machineconfiguration.openshift.io cloudcredential.openshift.io machine.openshift.io ocmagent.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [machineconfiguration.openshift.io operator.openshift.io network.openshift.io cloudcredential.openshift.io cloudingress.managed.openshift.io managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io config.openshift.io machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "scc-validation",
@@ -77,7 +93,7 @@
   },
   {
     "webhookName": "serviceaccount-validation",
-    "documentString": "Managed OpenShift Customers may not delete the service accounts under the managed namespaces。"
+    "documentString": "Managed OpenShift Customers may not create or delete service accounts in managed namespaces (excluding exception namespaces: default, openshift-logging, openshift-user-workload-monitoring, openshift-operators)."
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -87,6 +87,27 @@
     "documentString": "Managed OpenShift Customers may not change CustomResourceDefinitions managed by Red Hat."
   },
   {
+    "webhookName": "hcpnamespace-validation",
+    "rules": [
+      {
+        "operations": [
+          "DELETE"
+        ],
+        "apiGroups": [
+          ""
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "namespaces"
+        ],
+        "scope": "Cluster"
+      }
+    ],
+    "documentString": "Validates HCP namespace deletion operations are only performed by authorized service accounts"
+  },
+  {
     "webhookName": "hiveownership-validation",
     "rules": [
       {
@@ -112,6 +133,48 @@
       }
     },
     "documentString": "Managed OpenShift customers may not edit certain managed resources. A managed resource has a \"hive.openshift.io/managed\": \"true\" label."
+  },
+  {
+    "webhookName": "hostedcluster-validation",
+    "rules": [
+      {
+        "operations": [
+          "DELETE"
+        ],
+        "apiGroups": [
+          "hypershift.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "hostedclusters"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Validates HostedCluster deletion operations are only performed by authorized service accounts"
+  },
+  {
+    "webhookName": "hostedcontrolplane-validation",
+    "rules": [
+      {
+        "operations": [
+          "DELETE"
+        ],
+        "apiGroups": [
+          "hypershift.openshift.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "hostedcontrolplanes"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Validates HostedControlPlane deletion operations are only performed by authorized service accounts"
   },
   {
     "webhookName": "imagecontentpolicies-validation",
@@ -199,6 +262,27 @@
     "documentString": "Managed OpenShift Customer may create IngressControllers without necessary taints. This can cause those workloads to be provisioned on master nodes."
   },
   {
+    "webhookName": "manifestworks-validation",
+    "rules": [
+      {
+        "operations": [
+          "DELETE"
+        ],
+        "apiGroups": [
+          "work.open-cluster-management.io"
+        ],
+        "apiVersions": [
+          "*"
+        ],
+        "resources": [
+          "manifestworks"
+        ],
+        "scope": "Namespaced"
+      }
+    ],
+    "documentString": "Validates ManifestWorks deletion operations are only performed by authorized service accounts"
+  },
+  {
     "webhookName": "namespace-validation",
     "rules": [
       {
@@ -241,7 +325,7 @@
         "scope": "Cluster"
       }
     ],
-    "documentString": "Managed OpenShift customers may not modify critical fields in the network.operator CRD (such as spec.migration.networkType) because it can disrupt Cluster Network Operator operations and CNI migrations. Even cluster-admin users are blocked from modifying these critical fields."
+    "documentString": "Managed OpenShift customers may not modify critical fields in the network.operator CRD (such as spec.migration.networkType) because it can disrupt Cluster Network Operator operations and CNI migrations. Only backplane-cluster-admin, SRE, Cluster Network Operator (CNO), and Managed Upgrade Operator (MUO) service accounts are allowed to modify these critical fields. Regular cluster-admin users (system:admin) are explicitly blocked."
   },
   {
     "webhookName": "networkpolicies-validation",
@@ -498,7 +582,7 @@
         "scope": "*"
       }
     ],
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [splunkforwarder.managed.openshift.io autoscaling.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io config.openshift.io machineconfiguration.openshift.io operator.openshift.io network.openshift.io cloudcredential.openshift.io machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io cloudingress.managed.openshift.io managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [addons.managed.openshift.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io operator.openshift.io network.openshift.io machine.openshift.io managed.openshift.io ocmagent.managed.openshift.io autoscaling.openshift.io config.openshift.io machineconfiguration.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "scc-validation",
@@ -570,6 +654,7 @@
     "rules": [
       {
         "operations": [
+          "CREATE",
           "DELETE"
         ],
         "apiGroups": [
@@ -584,7 +669,7 @@
         "scope": "Namespaced"
       }
     ],
-    "documentString": "Managed OpenShift Customers may not delete the service accounts under the managed namespaces。"
+    "documentString": "Managed OpenShift Customers may not create or delete service accounts in managed namespaces (excluding exception namespaces: default, openshift-logging, openshift-user-workload-monitoring, openshift-operators)."
   },
   {
     "webhookName": "techpreviewnoupgrade-validation",

--- a/pkg/webhooks/serviceaccount/serviceaccount.go
+++ b/pkg/webhooks/serviceaccount/serviceaccount.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	WebhookName string = "serviceaccount-validation"
-	docString   string = `Managed OpenShift Customers may not delete the service accounts under the managed namespaces。`
+	docString   string = `Managed OpenShift Customers may not create or delete service accounts in managed namespaces (excluding exception namespaces: default, openshift-logging, openshift-user-workload-monitoring, openshift-operators).`
 )
 
 var (
@@ -30,7 +30,7 @@ var (
 	scope         = admissionregv1.NamespacedScope
 	rules         = []admissionregv1.RuleWithOperations{
 		{
-			Operations: []admissionregv1.OperationType{"DELETE"},
+			Operations: []admissionregv1.OperationType{"CREATE", "DELETE"},
 			Rule: admissionregv1.Rule{
 				APIGroups:   []string{""},
 				APIVersions: []string{"v1"},
@@ -115,6 +115,15 @@ func (s *serviceAccountWebhook) authorized(request admissionctl.Request) admissi
 	}
 
 	if isProtectedNamespace(request) && !isAllowedUserGroup(request) {
+		// Block CREATE operations in protected namespaces
+		if request.Operation == admissionv1.Create {
+			log.Info(fmt.Sprintf("CREATE operation denied for service account in protected namespace: %v", request.Namespace))
+			ret = admissionctl.Denied(fmt.Sprintf("Creating service accounts in managed namespace %v is not allowed", request.Namespace))
+			ret.UID = request.AdmissionRequest.UID
+			return ret
+		}
+
+		// Block DELETE operations in protected namespaces (existing logic)
 		if request.Operation == admissionv1.Delete && !isAllowedServiceAccount(sa) {
 			log.Info(fmt.Sprintf("Deleting operation detected on proteced serviceaccount: %v", sa.Name))
 			ret = admissionctl.Denied(fmt.Sprintf("Deleting protected service account under namespace %v is not allowed", request.Namespace))
@@ -134,8 +143,12 @@ func (s *serviceAccountWebhook) renderServiceAccount(request admissionctl.Reques
 	sa := &corev1.ServiceAccount{}
 
 	var err error
+	// For DELETE: use OldObject (the object being deleted)
+	// For CREATE: use Object (the object being created)
 	if len(request.OldObject.Raw) > 0 {
 		err = decoder.DecodeRaw(request.OldObject, sa)
+	} else if len(request.Object.Raw) > 0 {
+		err = decoder.Decode(request, sa)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/webhooks/serviceaccount/serviceaccount_test.go
+++ b/pkg/webhooks/serviceaccount/serviceaccount_test.go
@@ -148,3 +148,99 @@ func TestSADeletion(t *testing.T) {
 	}
 	runServiceAccountTests(t, tests)
 }
+
+func TestSACreation(t *testing.T) {
+	tests := []serviceAccountTestSuites{
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "user-cannot-create-sa-in-protected-ns",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-ingress-operator",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "user-can-create-sa-in-normal-ns",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "my-namespace",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "user-can-create-sa-in-default-ns",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "default",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "user-can-create-sa-in-openshift-logging",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-logging",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "user-can-create-sa-in-openshift-operators",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-operators",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "user-can-create-sa-in-openshift-user-workload-monitoring",
+			username:        "user1",
+			userGroups:      []string{"system:authenticated", "system:authenticated:oauth"},
+			namespace:       "openshift-user-workload-monitoring",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "sre-can-create-sa-in-protected-ns",
+			username:        "user1",
+			userGroups:      []string{"system:serviceaccounts:openshift-backplane-srep"},
+			namespace:       "openshift-ingress-operator",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "backplane-admin-can-create-sa-in-protected-ns",
+			username:        "backplane-cluster-admin",
+			userGroups:      []string{"system:authenticated"},
+			namespace:       "openshift-ingress-operator",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "system-user-can-create-sa-in-protected-ns",
+			username:        "system:serviceaccount:kube-system:controller",
+			userGroups:      []string{"system:serviceaccounts"},
+			namespace:       "openshift-ingress-operator",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			targetSA:        "my-custom-sa",
+			testID:          "kube-user-can-create-sa-in-protected-ns",
+			username:        "kube:admin",
+			userGroups:      []string{"system:authenticated"},
+			namespace:       "openshift-ingress-operator",
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+	}
+	runServiceAccountTests(t, tests)
+}


### PR DESCRIPTION
### Background
- The ServiceAccount validating webhook currently registers only `DELETE` operations for protected managed namespaces. 
- This creates an inconsistent lifecycle policy: customers can create ServiceAccounts in managed namespaces but may not be able to delete them later, leaving orphaned resources.
- PR [#497](https://github.com/openshift/managed-cluster-validating-webhooks/pull/497) previously added `default` to exceptionNamespaces so customer-managed ServiceAccounts there remain creatable and deletable. This change preserves that existing behavior.

### What
- Register both CREATE and DELETE operations for the ServiceAccount webhook.
- Deny customer CREATE requests and keep the existing DELETE behavior in protected managed namespaces.

### Other highlights for reviewers
- Regenerated the Classic SelectorSyncSet manifest and the HyperShift Package Operator resource bundle, so both deployment paths now include the updated CREATE and DELETE webhook operations. 
- The generated webhook documentation has also been refreshed to match the new behavior.
- More Context: [ROSAENG-963](https://redhat.atlassian.net/browse/ROSAENG-963)

### Validation in Staging
#### Test env
```
Cluster ID: 2qntit1spoe0udi9ss08qbb12g63ong2
Cluster Name: shawn-dev-classic
Version: 4.21.17
```
#### with this PR
- self-build image based on this PR
```
oc -n openshift-validation-webhook get daemonset validation-webhook -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'

quay.io/sbai_openshift/managed-cluster-validating-webhooks:mcvw-shawn-test-358f581
```
- **validatingwebhookconfiguration**
```
oc get validatingwebhookconfiguration sre-serviceaccount-validation -o jsonpath='{.webhooks[0].rules[0].operations}{"\n"}' 

The webhook registration changed from:
["DELETE"]

to:

["CREATE", "DELETE"]
```

#### E2E Test
- self-created `htpasswd` IDP to simulate a normal user as customer
```
KUBECONFIG="${CUSTOMER_KUBECONFIG}" oc whoami
mcvw-shawn-test-user

echo ${PROTECTED_NS}                                                                                                                            SIGINT 
openshift-ingress-operator

KUBECONFIG="${CUSTOMER_KUBECONFIG}" oc auth can-i create serviceaccounts -n "${PROTECTED_NS}" 
yes
```
- Customer CREATE and DELETE remain allowed in the default namespace, preserving the exception introduced by PR #497 
```
KUBECONFIG="${CUSTOMER_KUBECONFIG}" oc -n default create serviceaccount mcvw-shawn-test-create-allowed --dry-run=server                        SIGINT 
serviceaccount/mcvw-shawn-test-create-allowed created (server dry run)

KUBECONFIG="${CUSTOMER_KUBECONFIG}" oc -n default delete serviceaccount mcvw-shawn-test-create-allowed --dry-run=server
serviceaccount "mcvw-shawn-test-create-allowed" deleted from default namespace (server dry run)
```
- Customer CREATE is denied by the admission webhook in the protected `openshift-ingress-operator` namespace
```
KUBECONFIG="${CUSTOMER_KUBECONFIG}" oc -n "${PROTECTED_NS}" create serviceaccount mcvw-shawn-test-create-denied --dry-run=server

error: failed to create serviceaccount: admission webhook "serviceaccount-validation.managed.openshift.io" denied the request: Creating service accounts in managed namespace openshift-ingress-operator is not allowed
```
- Existing customer DELETE protection remains unchanged in protected managed namespaces
```
KUBECONFIG="${CUSTOMER_KUBECONFIG}" oc -n "${PROTECTED_NS}" delete serviceaccount ingress-operator --dry-run=server
Error from server (Forbidden): admission webhook "serviceaccount-validation.managed.openshift.io" denied the request: Deleting protected service account under namespace openshift-ingress-operator is not allowed
```

#### Validation on ROSA HCP
- The HyperShift Package Operator resource bundle has also been regenerated with `make package` and includes both CREATE and DELETE operations for sre-serviceaccount-validation.
```
yq eval '                                                                                                                                            1 
  select(
    .kind == "ValidatingWebhookConfiguration"
    and .metadata.name == "sre-serviceaccount-validation"
  )
  | .webhooks[0].rules[0].operations
' config/package/resources.yaml.gotmpl
- CREATE
- DELETE
```
- ROSA HCP runtime validation can be completed in staging after merge this PR through the standard PKO rollout path.

[ROSAENG-963]: https://redhat.atlassian.net/browse/ROSAENG-963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ