### PR TITLE
Updating Go toolset 1.26

### DIFF
--- a/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25
+    - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -96,7 +96,7 @@ spec:
       name: build-image-index
       type: string
     - default:
-      - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25
+      - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array

--- a/.tekton/managed-cluster-validating-webhooks-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-push.yaml
@@ -29,7 +29,7 @@ spec:
     value: .
   - name: build-args
     value:
-    - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25
+    - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -93,7 +93,7 @@ spec:
       name: build-image-index
       type: string
     - default:
-      - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25
+      - BASE_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.25.9-1777043046
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.26-1780490420
 FROM ${BASE_IMAGE} AS builder
 
 WORKDIR /opt/app-root/src

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.26-1780490420
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/go-toolset:1.26.3-1780490420
 FROM ${BASE_IMAGE} AS builder
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
We have [PRs](https://github.com/openshift/managed-cluster-validating-webhooks/pull/544) raised by the bot failing and require updating the Go toolset to version 1.26. Kube dependencies to v0.36.1, which pulled in go >= 1.26.0

After checking, I can see that it was released today https://catalog.redhat.com/en/software/containers/rhel9/go-toolset/61df08166d9a1b7b2aab2344#overview



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling base image to latest version for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->