### PR TITLE
removing old BearerTokenSecret field that not used in promethous 9

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -279,9 +279,6 @@ func createServiceMonitor() *monitoringv1.ServiceMonitor {
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{
 				{
-					BearerTokenSecret: corev1.SecretKeySelector{
-						Key: "",
-					},
 					Port: "metrics",
 				},
 			},


### PR DESCRIPTION
It was identified that PR https://github.com/openshift/managed-cluster-validating-webhooks/pull/509 is failing for unknown/removed fields in newer versions of Phometheous
```
build/resources.go:282:6: unknown field BearerTokenSecret in struct literal of type "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1".Endpoint
FAIL	github.com/openshift/managed-cluster-validating-webhooks/build [build failed]
```
After comparing [v0.55.1](https://github.com/prometheus-operator/prometheus-operator/blob/08c846115c67195bc821018168040db6f3e236e3/pkg/apis/monitoring/v1/types.go#L977) and [0.91.0](https://github.com/prometheus-operator/prometheus-operator/blob/v0.91.0/pkg/apis/monitoring/v1/types.go), the field is not used anymore. 

Fixing MCVW to align with a new change.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated webhook metrics scraping configuration to streamline authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->