### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+- joshbranham
+- srep-functional-team-rocket
+- srep-functional-team-thor
+approvers:
+- joshbranham
+- tnierman
+- srep-functional-leads
+- srep-team-leads
+- srep-functional-team-thor


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.