### PR TITLE
exclude kube-system ns from serviceaccount webhook

### DIFF
--- a/pkg/webhooks/serviceaccount/serviceaccount.go
+++ b/pkg/webhooks/serviceaccount/serviceaccount.go
@@ -52,6 +52,7 @@ var (
 	}
 	exceptionNamespaces = []string{
 		"default",
+		"kube-system",
 		"openshift-logging",
 		"openshift-user-workload-monitoring",
 		"openshift-operators",


### PR DESCRIPTION
Add kube-system as exception for the service account webhook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the set of protected namespace exceptions to include the `kube-system` namespace, improving service account admission control handling for system-level operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->