### PR TITLE
ROSA-745: boilerplate-update and enable MintMaker gomod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,12 +5,27 @@
   ],
   "packageRules": [
     {
-      "description": "KFLUXSPRT-8235: Prow/Tide repo — pre-label lgtm/approved; Tide merges after CI (no Renovate/platform automerge)",
-      "matchManagers": ["gomod", "tekton"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "description": "KFLUXSPRT-8235: Prow/Tide repo \u2014 pre-label lgtm/approved; Tide merges after CI (no Renovate/platform automerge)",
+      "matchManagers": [
+        "gomod",
+        "tekton"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": false,
       "platformAutomerge": false,
-      "addLabels": ["lgtm", "approved"]
+      "addLabels": [
+        "lgtm",
+        "approved"
+      ]
     }
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
   ]
 }


### PR DESCRIPTION
## Summary

- `make boilerplate-update` (includes boilerplate #748 dependabot template)
- `.github/renovate.json` — `enabledManagers: [tekton, gomod]` for MintMaker gomod PRs

## Test plan

- [ ] CI green

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)


[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation configuration to explicitly enable additional manager support for improved dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->