### PR TITLE
[ROSAENG-999] Refine imagecontentpolicies webhook to use path-specific denylist

### DIFF
--- a/docs/webhooks-short.json
+++ b/docs/webhooks-short.json
@@ -33,7 +33,7 @@
   },
   {
     "webhookName": "imagecontentpolicies-validation",
-    "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors that would conflict with system registries (e.g. quay.io, registry.redhat.io, registry.access.redhat.com, etc). For more details, see https://docs.openshift.com/"
+    "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for system registries (registry.redhat.io, registry.access.redhat.com, registry.ci.openshift.org, registry.connect.redhat.com) or managed service image repositories on quay.io (openshift-release-dev, openshift, app-sre, redhat-services-prod/openshift, redhat-services-prod/splunk-audit-exporter-tenant, etc.). This protects cluster stability by preventing redirection of critical platform and operator images. Customer-owned quay.io organizations are permitted. For more details, see https://docs.openshift.com/"
   },
   {
     "webhookName": "ingress-config-validation",
@@ -77,7 +77,7 @@
   },
   {
     "webhookName": "regular-user-validation",
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [machineconfiguration.openshift.io operator.openshift.io network.openshift.io cloudcredential.openshift.io cloudingress.managed.openshift.io managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io config.openshift.io machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io ocmagent.managed.openshift.io upgrade.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [cloudcredential.openshift.io machine.openshift.io admissionregistration.k8s.io addons.managed.openshift.io cloudingress.managed.openshift.io upgrade.managed.openshift.io config.openshift.io machineconfiguration.openshift.io managed.openshift.io ocmagent.managed.openshift.io splunkforwarder.managed.openshift.io autoscaling.openshift.io operator.openshift.io network.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "scc-validation",

--- a/docs/webhooks.json
+++ b/docs/webhooks.json
@@ -213,7 +213,7 @@
         "scope": "Cluster"
       }
     ],
-    "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors that would conflict with system registries (e.g. quay.io, registry.redhat.io, registry.access.redhat.com, etc). For more details, see https://docs.openshift.com/"
+    "documentString": "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for system registries (registry.redhat.io, registry.access.redhat.com, registry.ci.openshift.org, registry.connect.redhat.com) or managed service image repositories on quay.io (openshift-release-dev, openshift, app-sre, redhat-services-prod/openshift, redhat-services-prod/splunk-audit-exporter-tenant, etc.). This protects cluster stability by preventing redirection of critical platform and operator images. Customer-owned quay.io organizations are permitted. For more details, see https://docs.openshift.com/"
   },
   {
     "webhookName": "ingress-config-validation",
@@ -582,7 +582,7 @@
         "scope": "*"
       }
     ],
-    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [addons.managed.openshift.io cloudingress.managed.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io operator.openshift.io network.openshift.io machine.openshift.io managed.openshift.io ocmagent.managed.openshift.io autoscaling.openshift.io config.openshift.io machineconfiguration.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
+    "documentString": "Managed OpenShift customers may not manage any objects in the following APIGroups [config.openshift.io operator.openshift.io cloudcredential.openshift.io admissionregistration.k8s.io ocmagent.managed.openshift.io autoscaling.openshift.io machineconfiguration.openshift.io network.openshift.io machine.openshift.io addons.managed.openshift.io cloudingress.managed.openshift.io managed.openshift.io splunkforwarder.managed.openshift.io upgrade.managed.openshift.io], nor may Managed OpenShift customers alter the APIServer, KubeAPIServer, OpenShiftAPIServer, ClusterVersion, Proxy or SubjectPermission objects."
   },
   {
     "webhookName": "scc-validation",

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies.go
@@ -17,11 +17,24 @@ import (
 
 const (
 	WebhookName = "imagecontentpolicies-validation"
-	WebhookDoc  = "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors that would conflict with system registries (e.g. quay.io, registry.redhat.io, registry.access.redhat.com, etc). For more details, see https://docs.openshift.com/"
-	// unauthorizedRepositoryMirrors is a regex that is used to reject certain specified repository mirrors.
-	// Only registry.redhat.io exactly is blocked, while all other contained regexes
-	// follow a similar pattern, i.e. rejecting quay.io or quay.io/.*
-	unauthorizedRepositoryMirrors = `(^registry\.redhat\.io$|^quay\.io(/.*)?$|^registry\.access\.redhat\.com(/.*)?)`
+	WebhookDoc  = "Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors for system registries (registry.redhat.io, registry.access.redhat.com, registry.ci.openshift.org, registry.connect.redhat.com) or managed service image repositories on quay.io (openshift-release-dev, openshift, app-sre, redhat-services-prod/openshift, redhat-services-prod/splunk-audit-exporter-tenant, etc.). This protects cluster stability by preventing redirection of critical platform and operator images. Customer-owned quay.io organizations are permitted. For more details, see https://docs.openshift.com/"
+	// unauthorizedRepositoryMirrors blocks entire Red Hat registries and specific quay.io organization paths
+	// used by the managed OpenShift platform and Red Hat services.
+	// Red Hat registries: registry.redhat.io, registry.access.redhat.com, registry.ci.openshift.org, registry.connect.redhat.com
+	// Quay.io blocked orgs: app-sre, observatorium, openshift-logging, openshift-release-dev, openshift, prometheus,
+	//                       redhat-services-prod/openshift, redhat-services-prod/splunk-audit-exporter-tenant
+	unauthorizedRepositoryMirrors = `(^registry\.redhat\.io(/.*)?$|` +
+		`^registry\.access\.redhat\.com(/.*)?$|` +
+		`^registry\.ci\.openshift\.org(/.*)?$|` +
+		`^registry\.connect\.redhat\.com(/.*)?$|` +
+		`^quay\.io/app-sre(/.*)?$|` +
+		`^quay\.io/observatorium(/.*)?$|` +
+		`^quay\.io/openshift-logging(/.*)?$|` +
+		`^quay\.io/openshift-release-dev(/.*)?$|` +
+		`^quay\.io/openshift(/.*)?$|` +
+		`^quay\.io/prometheus(/.*)?$|` +
+		`^quay\.io/redhat-services-prod/openshift(/.*)?$|` +
+		`^quay\.io/redhat-services-prod/splunk-audit-exporter-tenant(/.*)?$)`
 )
 
 type ImageContentPoliciesWebhook struct {

--- a/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
+++ b/pkg/webhooks/imagecontentpolicies/imagecontentpolicies_test.go
@@ -22,23 +22,7 @@ func Test_authorizeImageDigestMirrorSet(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "quay.io",
-			idms: configv1.ImageDigestMirrorSet{
-				Spec: configv1.ImageDigestMirrorSetSpec{
-					ImageDigestMirrors: []configv1.ImageDigestMirrors{
-						{
-							Source: "quay.io",
-						},
-						{
-							Source: "quay.io/something",
-						},
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "registry.redhat.io",
+			name: "blocked: registry.redhat.io",
 			idms: configv1.ImageDigestMirrorSet{
 				Spec: configv1.ImageDigestMirrorSetSpec{
 					ImageDigestMirrors: []configv1.ImageDigestMirrors{
@@ -51,15 +35,12 @@ func Test_authorizeImageDigestMirrorSet(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "registry.access.redhat.com",
+			name: "blocked: registry.redhat.io with path",
 			idms: configv1.ImageDigestMirrorSet{
 				Spec: configv1.ImageDigestMirrorSetSpec{
 					ImageDigestMirrors: []configv1.ImageDigestMirrors{
 						{
-							Source: "registry.access.redhat.com",
-						},
-						{
-							Source: "registry.access.redhat.com/something",
+							Source: "registry.redhat.io/openshift4/ose-cli",
 						},
 					},
 				},
@@ -67,15 +48,158 @@ func Test_authorizeImageDigestMirrorSet(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "example.com",
+			name: "blocked: registry.access.redhat.com",
 			idms: configv1.ImageDigestMirrorSet{
 				Spec: configv1.ImageDigestMirrorSetSpec{
 					ImageDigestMirrors: []configv1.ImageDigestMirrors{
 						{
-							Source: "registry.redhat.io/something",
+							Source: "registry.access.redhat.com",
 						},
 						{
+							Source: "registry.access.redhat.com/ubi8/pause",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: registry.ci.openshift.org",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "registry.ci.openshift.org/ocp/release-5",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: registry.connect.redhat.com",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "registry.connect.redhat.com/dynatrace/dynatrace-operator",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/openshift-release-dev",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "quay.io/openshift-release-dev/ocp-release",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/openshift",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "quay.io/openshift/origin-kube-state-metrics",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/app-sre",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "quay.io/app-sre/managed-cluster-validating-webhooks",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/redhat-services-prod/openshift",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "quay.io/redhat-services-prod/openshift/addon-operator",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/prometheus",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "quay.io/prometheus/blackbox-exporter",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "allowed: quay.io/redhat-services-prod/some-org",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "quay.io/redhat-services-prod/some-org/my-image",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed: example.com",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
 							Source: "example.com",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed: gcr.io",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "gcr.io/my-project/my-app",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed: docker.io",
+			idms: configv1.ImageDigestMirrorSet{
+				Spec: configv1.ImageDigestMirrorSetSpec{
+					ImageDigestMirrors: []configv1.ImageDigestMirrors{
+						{
+							Source: "docker.io/library/nginx",
 						},
 					},
 				},
@@ -100,23 +224,7 @@ func Test_authorizeImageTagMirrorSet(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "quay.io",
-			itms: configv1.ImageTagMirrorSet{
-				Spec: configv1.ImageTagMirrorSetSpec{
-					ImageTagMirrors: []configv1.ImageTagMirrors{
-						{
-							Source: "quay.io",
-						},
-						{
-							Source: "quay.io/something",
-						},
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "registry.redhat.io",
+			name: "blocked: registry.redhat.io",
 			itms: configv1.ImageTagMirrorSet{
 				Spec: configv1.ImageTagMirrorSetSpec{
 					ImageTagMirrors: []configv1.ImageTagMirrors{
@@ -129,15 +237,12 @@ func Test_authorizeImageTagMirrorSet(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "registry.access.redhat.com",
+			name: "blocked: registry.redhat.io with path",
 			itms: configv1.ImageTagMirrorSet{
 				Spec: configv1.ImageTagMirrorSetSpec{
 					ImageTagMirrors: []configv1.ImageTagMirrors{
 						{
-							Source: "registry.access.redhat.com",
-						},
-						{
-							Source: "registry.access.redhat.com/something",
+							Source: "registry.redhat.io/rhacm2/config-policy-controller-rhel9",
 						},
 					},
 				},
@@ -145,15 +250,119 @@ func Test_authorizeImageTagMirrorSet(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "example.com",
+			name: "blocked: registry.access.redhat.com",
 			itms: configv1.ImageTagMirrorSet{
 				Spec: configv1.ImageTagMirrorSetSpec{
 					ImageTagMirrors: []configv1.ImageTagMirrors{
 						{
-							Source: "registry.redhat.io/something",
+							Source: "registry.access.redhat.com",
 						},
 						{
+							Source: "registry.access.redhat.com/ubi8/pause",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: registry.ci.openshift.org",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "registry.ci.openshift.org/ocp/release-5",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: registry.connect.redhat.com",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "registry.connect.redhat.com/dynatrace/dynatrace-operator",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/openshift-logging",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "quay.io/openshift-logging/eventrouter",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/observatorium",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "quay.io/observatorium/token-refresher",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/redhat-services-prod/splunk-audit-exporter-tenant",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "quay.io/redhat-services-prod/splunk-audit-exporter-tenant/splunk-audit-exporter/splunk-audit-exporter",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "allowed: quay.io/redhat-services-prod/some-org",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "quay.io/redhat-services-prod/some-org",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed: example.com",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
 							Source: "example.com",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed: quay.io/customer-org",
+			itms: configv1.ImageTagMirrorSet{
+				Spec: configv1.ImageTagMirrorSetSpec{
+					ImageTagMirrors: []configv1.ImageTagMirrors{
+						{
+							Source: "quay.io/customer-org/my-app",
 						},
 					},
 				},
@@ -178,23 +387,7 @@ func Test_authorizeImageContentSourcePolicy(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "quay.io",
-			icsp: operatorv1alpha1.ImageContentSourcePolicy{
-				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
-					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
-						{
-							Source: "quay.io",
-						},
-						{
-							Source: "quay.io/something",
-						},
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "registry.redhat.io",
+			name: "blocked: registry.redhat.io",
 			icsp: operatorv1alpha1.ImageContentSourcePolicy{
 				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -210,7 +403,7 @@ func Test_authorizeImageContentSourcePolicy(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "registry.access.redhat.com",
+			name: "blocked: registry.access.redhat.com",
 			icsp: operatorv1alpha1.ImageContentSourcePolicy{
 				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -226,7 +419,59 @@ func Test_authorizeImageContentSourcePolicy(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "example.com",
+			name: "blocked: registry.ci.openshift.org",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "registry.ci.openshift.org/ocp/release-5",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: registry.connect.redhat.com",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "registry.connect.redhat.com/dynatrace/dynatrace-operator",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "blocked: quay.io/app-sre",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "quay.io/app-sre/suricata",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "allowed: quay.io/redhat-services-prod/some-org",
+			icsp: operatorv1alpha1.ImageContentSourcePolicy{
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source: "quay.io/redhat-services-prod/some-org",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "allowed: example.com",
 			icsp: operatorv1alpha1.ImageContentSourcePolicy{
 				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
@@ -361,7 +606,7 @@ func TestImageContentPolicy(t *testing.T) {
 			name: "unauthorized-creation-idms",
 			op:   admissionv1.Create,
 			obj: &runtime.RawExtension{
-				Raw: []byte(fmt.Sprintf(rawImageDigestMirrorSet, "quay.io")),
+				Raw: []byte(fmt.Sprintf(rawImageDigestMirrorSet, "quay.io/openshift-release-dev/ocp-release")),
 			},
 			gvk:     idmsgvk,
 			gvr:     idmsgvr,
@@ -407,7 +652,7 @@ func TestImageContentPolicy(t *testing.T) {
 			name: "unauthorized-creation-itms",
 			op:   admissionv1.Create,
 			obj: &runtime.RawExtension{
-				Raw: []byte(fmt.Sprintf(rawImageTagMirrorSet, "quay.io")),
+				Raw: []byte(fmt.Sprintf(rawImageTagMirrorSet, "quay.io/app-sre/compliance-monkey")),
 			},
 			gvk:     itmsgvk,
 			gvr:     itmsgvr,
@@ -453,7 +698,7 @@ func TestImageContentPolicy(t *testing.T) {
 			name: "unauthorized-creation-icp",
 			op:   admissionv1.Create,
 			obj: &runtime.RawExtension{
-				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "quay.io")),
+				Raw: []byte(fmt.Sprintf(rawImageContentSourcePolicy, "registry.redhat.io/openshift4/ose-cli")),
 			},
 			gvk:     icspgvk,
 			gvr:     icspgvr,


### PR DESCRIPTION
Assisted by AI.

## Why
The current `imagecontentpolicies-validation` webhook blocks all image sources under `quay.io/*`, which prevents customers from creating mirrors for their own organization-scoped repositories that don't conflict with managed service images.

Problem scenario:

A customer wants to add a GCR mirror fallback for their images at quay.io/redhat-services-prod/xxxxx:

```
source: quay.io/redhat-services-prod/xxxxxxx
mirrors:
  - quay.io/redhat-services-prod/xxxxxxx
  - gcr.io/xxxxxxx
mirrorSourcePolicy: AllowContactingSource
```
This is currently blocked by the webhook even though:
- It's scoped to a specific customer organization
- It doesn't affect system images like `quay.io/openshift-release-dev/*` or `quay.io/redhat-services-prod/openshift/*`
- It uses AllowContactingSource, so it's only a fallback mirror
 

Root cause:
The original regex `^quay\.io(/.*)?$` blocks the entire `quay.io` domain and all paths under it, treating organization-scoped mirrors the same as domain-wide redirects.


## What
This PR refines the webhook to use a path-specific denylist instead of a wide matching, allowing customer to mirror image repos which are not used by the managed service.

The deny list:
```
registry.redhat.io/*
registry.access.redhat.com/*
registry.ci.openshift.org/*
registry.connect.redhat.com/*
quay.io/app-sre/*
quay.io/observatorium/*
quay.io/openshift-logging/*
quay.io/openshift-release-dev/*
quay.io/openshift/*
quay.io/prometheus/*
quay.io/redhat-services-prod/openshift/*
quay.io/redhat-services-prod/splunk-audit-exporter-tenant/*
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised image mirror and content policy validation documentation to explicitly specify blocked system registries and confirm that customer-owned quay.io organizations are permitted as mirror sources
  * Enhanced regular user validation documentation with updated API group restriction specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->