### PR TITLE
changing tekton sha to address failing checks

### DIFF
--- a/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
@@ -374,7 +374,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:ba08e3b2dac65b0938ee312a9d6956770b98d99916100c2f9869f0090db3ad68
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:ba08e3b2dac65b0938ee312a9d6956770b98d99916100c2f9869f0090db3ad68
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
@@ -367,7 +367,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:ba08e3b2dac65b0938ee312a9d6956770b98d99916100c2f9869f0090db3ad68
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-push.yaml
@@ -364,7 +364,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:2db846fa5d8e593b4def045693d79ebd01802ec6edeea0f6003a23167a8a078e
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:ba08e3b2dac65b0938ee312a9d6956770b98d99916100c2f9869f0090db3ad68
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
we have pr that failing due to outdate tekton sha https://github.com/openshift/managed-cluster-validating-webhooks/pull/567/checks?check_run_id=82650966220

```
› [Warning] test.no_failed_informative_tests
  ImageRef: quay.io/redhat-user-workloads/managed-cluster-validating-webhooks-tenant/openshift/managed-cluster-validating-webhooks-e2e@sha256:d217ca95fd723d1ad51d817192713ae6e553fbabdb4f17526a062bbbfd8ae201
  Reason: The Task "ecosystem-cert-preflight-checks" from the build Pipeline reports a failed informative test
  Term: ecosystem-cert-preflight-checks
  Title: No informative tests failed
  Description: Produce a warning if any informative tests have their result set to "FAILED". The result type is configurable by
  the "failed_tests_results" key, and the list of informative tests is configurable by the "informative_tests" key in the rule
  data.
  Solution: There is a test that failed. Make sure that any task in the build pipeline with a result named 'TEST_OUTPUT' does not
  fail. More information about the test should be available in the logs for the build Pipeline.
```

The logs suggests to update to newer sha

```
› [Warning] trusted_task.current
  ImageRef: quay.io/redhat-user-workloads/managed-cluster-validating-webhooks-tenant/openshift/managed-cluster-validating-webhooks@sha256:76f21f1e59b677afcf851c7b21baf7996e502e4c05f5e67e69a1c51386153491
  Reason: A newer version of task "sast-snyk-check" exists. Please update before 2026-08-18T00:00:00Z. The current bundle is
  "oci://quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:bc1328059d7d91d8fc3b7bf066a54bb0bb2442df2df890020c4f2bfed49d79a9"
  and the latest bundle ref is "sha256:ba08e3b2dac65b0938ee312a9d6956770b98d99916100c2f9869f0090db3ad68"
  Term: sast-snyk-check-oci-ta
  Title: Tasks using the latest versions
  Description: Check if all Tekton Tasks use the latest known Task reference. When warnings will be reported can be configured
  using the `task_expiry_warning_days` rule data setting. It holds the number of days before the task is to expire within which
  the warnings will be reported.
  Solution: Update the Task reference to a newer version.
 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning task references across pipeline configurations to use the latest versions, ensuring improved vulnerability detection and compliance checks in CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->