### PR TITLE
ROSAENG-60641: Allow privileged service accounts to create NetworkPolicies in openshift-ingress

### DIFF
--- a/pkg/webhooks/networkpolicies/networkpolicies.go
+++ b/pkg/webhooks/networkpolicies/networkpolicies.go
@@ -96,6 +96,16 @@ func (s *networkpoliciesruleWebhook) authorized(request admissionctl.Request) ad
 	}
 
 	if np.GetNamespace() == "openshift-ingress" {
+		// Allow privileged service accounts (e.g. redhat-*, openshift-*) to
+		// manage NetworkPolicies for non-ingress-controller pods deployed in
+		// this namespace, such as kube-auth-proxy or payload-processing.
+		for _, group := range request.UserInfo.Groups {
+			if privilegedServiceAccountGroupsRe.Match([]byte(group)) {
+				ret = admissionctl.Allowed(fmt.Sprintf("Privileged service accounts in group(s) '%s' can operate on NetworkPolicies in openshift-ingress", strings.Join(request.UserInfo.Groups, ", ")))
+				ret.UID = request.AdmissionRequest.UID
+				return ret
+			}
+		}
 		ingressName, labelFound := np.Spec.PodSelector.MatchLabels["ingresscontroller.operator.openshift.io/deployment-ingresscontroller"]
 		if !labelFound || ingressName == "default" {
 			ret = admissionctl.Denied(fmt.Sprintf("User '%s' prevented from creating network policy that may impact default ingress, which is managed by Red Hat. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support", request.UserInfo.Username))

--- a/pkg/webhooks/networkpolicies/networkpolicies_test.go
+++ b/pkg/webhooks/networkpolicies/networkpolicies_test.go
@@ -82,6 +82,12 @@ func (t crudTest) redhatServiceAccount() crudTest {
 	return t
 }
 
+func (t crudTest) rhoaiServiceAccount() crudTest {
+	t.testData.username = "system:serviceaccount:redhat-ods-operator:redhat-ods-operator-controller-manager"
+	t.testData.userGroups = []string{"system:serviceaccounts:redhat-ods-operator", "system:authenticated", "system:authenticated:oauth"}
+	return t
+}
+
 func (t crudTest) namespace(namespace string) crudTest {
 	t.testData.targetNamespace = namespace
 	return t
@@ -244,6 +250,24 @@ func TestUsers(t *testing.T) {
 		updateFrom(createRawJSONString("openshift-ingress", map[string]string{"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"})).
 		podSelector("ingresscontroller.operator.openshift.io/deployment-ingresscontroller", "custom").
 		regularUser().shouldBeAllowed())
+
+	// Privileged service accounts (redhat-*, openshift-*) should be allowed
+	// to create NetworkPolicies in openshift-ingress without the ingress
+	// controller label. This is needed for operators like RHOAI that deploy
+	// pods (kube-auth-proxy, payload-processing) into openshift-ingress.
+	tests = append(tests, newCrudTest("rhoai-sa-openshift-ingress-no-ingress-label").
+		namespace("openshift-ingress").
+		podSelector("app", "kube-auth-proxy").
+		rhoaiServiceAccount().shouldBeAllowedCRUD()...)
+	tests = append(tests, newCrudTest("privileged-sa-openshift-ingress-no-ingress-label").
+		namespace("openshift-ingress").
+		podSelector("app", "payload-processing").
+		allowedServiceAccount().shouldBeAllowedCRUD()...)
+	// Unprivileged SAs should still be denied
+	tests = append(tests, newCrudTest("unprivileged-sa-openshift-ingress-no-ingress-label").
+		namespace("openshift-ingress").
+		podSelector("app", "some-pod").
+		unprivilegedServiceAccount().shouldBeDeniedCRUD()...)
 
 	runNetworkPolicyTests(t, tests)
 }


### PR DESCRIPTION
### Summary

OCP 4.22 introduced a deny-all NetworkPolicy (`openshift-ingress-deny-all`) in the `openshift-ingress` namespace via [NE-2501](https://issues.redhat.com/browse/NE-2501). This requires operators that deploy pods into `openshift-ingress` to create explicit allow NetworkPolicies for their pods.

The current webhook logic has a special case for `openshift-ingress` that skips the privileged SA check entirely and only allows NPs whose podSelector contains `ingresscontroller.operator.openshift.io/deployment-ingresscontroller` with a non-`default` value. This blocks privileged service accounts (matching `redhat-*`, `openshift-*`, etc.) from creating NetworkPolicies for non-ingress-controller pods in that namespace.

The flow today:
1. `isAllowedNamespace("openshift-ingress")` returns `true` (explicit carve-out on [line 119](https://github.com/openshift/managed-cluster-validating-webhooks/blob/master/pkg/webhooks/networkpolicies/networkpolicies.go#L119))
2. This skips the `!isAllowedNamespace` block where the privileged SA regex is evaluated
3. Falls through to the `openshift-ingress` specific check which only looks at the ingress controller label
4. NPs without that label are denied regardless of SA privileges

This PR adds the privileged SA check before the ingress controller label check in the `openshift-ingress` block, so that trusted operators can manage NetworkPolicies for their own pods without requiring the ingress controller label.

Jira: [ROSAENG-60641](https://redhat.atlassian.net/browse/ROSAENG-60641)

### Context

RHOAI deploys pods into `openshift-ingress` as part of its gateway architecture. With the OCP 4.22 deny-all in place, the operator needs to create NetworkPolicies for those pods. On ROSA, the webhook blocks the operator SA (`system:serviceaccount:redhat-ods-operator:*`) from doing so, even though it matches the privileged SA regex (`redhat-*`). This makes RHOAI non-functional on ROSA + OCP 4.22.

- RHOAI bug: [RHOAIENG-70137](https://issues.redhat.com/browse/RHOAIENG-70137)

### Validation

- Added `rhoaiServiceAccount()` test helper simulating `system:serviceaccount:redhat-ods-operator:redhat-ods-operator-controller-manager`
- Added test: privileged SA (`redhat-*`) can CRUD NetworkPolicies in `openshift-ingress` without the ingress controller label
- Added test: privileged SA (`openshift-*`) can CRUD NetworkPolicies in `openshift-ingress` without the ingress controller label
- Added test: unprivileged SA is still denied when creating NPs in `openshift-ingress` without the label
- Existing tests unchanged and still pass

[NE-2501]: https://redhat.atlassian.net/browse/NE-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-60641]: https://redhat.atlassian.net/browse/ROSAENG-60641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests from privileged service accounts in the `openshift-ingress` namespace are now allowed to manage network policies even when the usual ingress-related label is missing.
  * Added coverage to ensure privileged accounts are granted access while unprivileged accounts continue to be denied in the same scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->