### PR TITLE
KFLUXSPRT-8235: disable Renovate automerge for Tide-managed MintMaker PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "packageRules": [
+    {
+      "description": "KFLUXSPRT-8235: Prow/Tide repo — pre-label lgtm/approved; Tide merges after CI (no Renovate/platform automerge)",
+      "matchManagers": ["gomod", "tekton"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": false,
+      "platformAutomerge": false,
+      "addLabels": ["lgtm", "approved"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Pilot fix for [KFLUXSPRT-8235](https://redhat.atlassian.net/browse/KFLUXSPRT-8235) on **managed-cluster-validating-webhooks** (first ROSA operator test repo per MintMaker thread).

MintMaker guidance for **Prow/Tide-integrated GitHub repos**: set `automerge: false` (and do not use platform automerge). Safe dependency PRs should get **`lgtm` + `approved`** labels and let **Tide** merge once mandatory `ci/prow/*` + Konflux `*-on-pull-request` checks pass.

This adds a repo-local `packageRules` override on top of boilerplate `renovate.json`:

- **gomod + tekton** patch/minor/pin/digest → `automerge: false`, `platformAutomerge: false`, `addLabels: [lgtm, approved]`
- **Major** updates unchanged (still manual via boilerplate rules)

Supersedes #555 (boilerplate-update / enabledManagers — already on `master` via extends).

## Context

- Premature Konflux bot merges with red e2e / missing prow were traced to platform automerge racing Tide
- Separate fleet issue: go.sum / artifact failures on grouped gomod PRs need repo-owner dep fixes (not this PR)
- Konflux `task-git-clone-oci-ta` 0.2 / acceptable bundles ([KFLUXSPRT-8263](https://redhat.atlassian.net/browse/KFLUXSPRT-8263)) may keep some MintMaker PRs red until platform fixes land — validation of Tide merge should wait for green CI

## Test plan

- [ ] Merge this config PR (prow + Konflux green)
- [ ] Next MintMaker patch/minor gomod or tekton PR: has `lgtm` + `approved`, **no** Renovate/platform automerge
- [ ] PR merges via **Tide** only after all required checks green
- [ ] Major MintMaker PR still opens without `lgtm`/`approved` — manual `/lgtm` required
- [ ] If successful, roll same override pattern fleet-wide (and follow-up boilerplate change)

## References

- MintMaker automerge docs: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html
- [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) / fleet tracker: openshift/backplane-cli `hack/rosa-745/`


Made with [Cursor](https://cursor.com)

[KFLUXSPRT-8235]: https://redhat.atlassian.net/browse/KFLUXSPRT-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXSPRT-8263]: https://redhat.atlassian.net/browse/KFLUXSPRT-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation to apply consistent labels for certain Go and Tekton updates.
  * Disabled automatic merging for minor, patch, pin, and digest updates in those categories, requiring manual review before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->