### PR TITLE
KFLUXSPRT-8263: trusted git-clone-oci-ta 0.2 digest

### DIFF
--- a/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
@@ -164,7 +164,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:52827a47564514f6accab971b8fad4f1c1cf59997507ed7c4e534615eeeae567
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
@@ -154,7 +154,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:52827a47564514f6accab971b8fad4f1c1cf59997507ed7c4e534615eeeae567
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
@@ -161,7 +161,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:52827a47564514f6accab971b8fad4f1c1cf59997507ed7c4e534615eeeae567
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-push.yaml
@@ -158,7 +158,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:52827a47564514f6accab971b8fad4f1c1cf59997507ed7c4e534615eeeae567
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

[KFLUXSPRT-8263](https://redhat.atlassian.net/browse/KFLUXSPRT-8263) — align `task-git-clone-oci-ta:0.2` Tekton bundle digest to the trusted entry in `quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles` after the platform acceptable-bundles refresh.

Trusted digest: `sha256:52827a47564514f6accab971b8fad4f1c1cf59997507ed7c4e534615eeeae567`

## Test plan

- [ ] Konflux `*-on-pull-request` green on this PR

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) / [KFLUXSPRT-8263](https://redhat.atlassian.net/browse/KFLUXSPRT-8263)


[KFLUXSPRT-8263]: https://redhat.atlassian.net/browse/KFLUXSPRT-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXSPRT-8263]: https://redhat.atlassian.net/browse/KFLUXSPRT-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ