### PR TITLE
ROSAENG-14287: fix(clusterrole): allow system:admin (Hive) to delete protected ClusterRoles

### DIFF
--- a/pkg/webhooks/clusterrole/clusterrole.go
+++ b/pkg/webhooks/clusterrole/clusterrole.go
@@ -55,6 +55,7 @@ var (
 	// Users allowed to delete protected ClusterRoles
 	allowedUsers = []string{
 		"backplane-cluster-admin",
+		"system:admin",
 	}
 
 	// Groups allowed to delete protected ClusterRoles

--- a/pkg/webhooks/clusterrole/clusterrole_test.go
+++ b/pkg/webhooks/clusterrole/clusterrole_test.go
@@ -52,6 +52,22 @@ var (
 			}
 		]
 	}`
+
+	// testBackplaneClusterRoleJSON represents a backplane-* protected ClusterRole
+	testBackplaneClusterRoleJSON = `{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind": "ClusterRole",
+		"metadata": {
+			"name": "backplane-lpsre-admins-project"
+		},
+		"rules": [
+			{
+				"apiGroups": [""],
+				"resources": ["pods"],
+				"verbs": ["get", "list"]
+			}
+		]
+	}`
 )
 
 func runClusterRoleTests(t *testing.T, tests []ClusterRoleTestSuites) {
@@ -68,9 +84,12 @@ func runClusterRoleTests(t *testing.T, tests []ClusterRoleTestSuites) {
 		}
 
 		var clusterRoleJSON string
-		if test.targetClusterRole == "cluster-admin" {
+		switch test.targetClusterRole {
+		case "cluster-admin":
 			clusterRoleJSON = testClusterRoleJSON
-		} else {
+		case "backplane-lpsre-admins-project":
+			clusterRoleJSON = testBackplaneClusterRoleJSON
+		default:
 			clusterRoleJSON = testOtherClusterRoleJSON
 		}
 
@@ -161,6 +180,22 @@ func TestClusterRoleDeletionPositive(t *testing.T) {
 			testID:            "system-user-allow",
 			username:          "system:kube-controller-manager",
 			userGroups:        []string{"system:authenticated"},
+			operation:         admissionv1.Delete,
+			shouldBeAllowed:   true,
+			targetClusterRole: "cluster-admin",
+		},
+		{
+			testID:            "hive-system-admin-allow-backplane-role",
+			username:          "system:admin",
+			userGroups:        []string{"system:authenticated", "system:masters"},
+			operation:         admissionv1.Delete,
+			shouldBeAllowed:   true,
+			targetClusterRole: "backplane-lpsre-admins-project",
+		},
+		{
+			testID:            "hive-system-admin-allow-protected-role",
+			username:          "system:admin",
+			userGroups:        []string{"system:authenticated", "system:masters"},
 			operation:         admissionv1.Delete,
 			shouldBeAllowed:   true,
 			targetClusterRole: "cluster-admin",


### PR DESCRIPTION
Hive uses system:admin to manage resources on target clusters. When a SyncSet is removed, Hive needs to delete the ClusterRoles it previously created. The webhook was denying these deletions because system:admin was explicitly excluded from the system: user bypass and was not in the allowedUsers list.

```
- failureMessage: '[failed to delete rbac.authorization.k8s.io/v1, Kind=ClusterRole
        /backplane-lpsre-admins-project: could not delete resource: admission webhook
        "clusterroles-validation.managed.openshift.io" denied the request: Deleting
        ClusterRole backplane-lpsre-admins-project is not allowed, failed to delete
        rbac.authorization.k8s.io/v1, Kind=ClusterRole /backplane-lpsre-monitoring-project:
        could not delete resource: admission webhook "clusterroles-validation.managed.openshift.io"
        denied the request: Deleting ClusterRole backplane-lpsre-monitoring-project
        is not allowed, failed to delete rbac.authorization.k8s.io/v1, Kind=ClusterRole
        /backplane-lpsre-package-operator-cluster: could not delete resource: admission
        webhook "clusterroles-validation.managed.openshift.io" denied the request:
        Deleting ClusterRole backplane-lpsre-package-operator-cluster is not allowed,
        failed to delete rbac.authorization.k8s.io/v1, Kind=ClusterRole /backplane-lpsre-package-operator-project:
        could not delete resource: admission webhook "clusterroles-validation.managed.openshift.io"
        denied the request: Deleting ClusterRole backplane-lpsre-package-operator-project
        is not allowed]'
      firstSuccessTime: "2026-03-27T08:25:17Z"
      lastTransitionTime: "2026-04-08T07:05:06Z"
      name: backplane-lpsre-addon-cert-manager-operator
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded ClusterRole deletion permissions so `system:admin` is now allowed to delete protected roles in approved cases.
  * Improved handling for protected “backplane” roles, reducing unexpected authorization failures during deletion.
  * Added coverage for these permission scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->