### PR TITLE
[Project Darkstar] PSHP-545: Remediate 18 CVEs in managed-cluster-validating-webhooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/managed-cluster-validating-webhooks
 
 go 1.26.0
 
+toolchain go1.26.3
+
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
## [Project Darkstar] [PSHP-545](https://redhat.atlassian.net/browse/PSHP-545): Remediate CVEs in managed-cluster-validating-webhooks

### Changes
- Add `toolchain go1.26.3` to go.mod to pin Go stdlib to version with security patches (fixes 6 stdlib CVEs)

### Already Fixed (3 CVEs)
The following CVEs are already resolved in the current source:
- CVE-2026-39821 (golang.org/x/net, CVSS 8.2) — current v0.57.0 >= fix v0.55.0
- CVE-2026-25681 (golang.org/x/net, CVSS 8.1) — current v0.57.0 >= fix v0.55.0
- CVE-2026-27136 (golang.org/x/net, CVSS 8.1) — current v0.57.0 >= fix v0.55.0

### Fixed by Rebuild — Go stdlib (6 CVEs)
Builder image already at go-toolset:1.26.3. Adding `toolchain go1.26.3` to go.mod ensures all build environments use Go 1.26.3 stdlib:
- CVE-2026-42499 (stdlib, CVSS 7.5) — fix: Go 1.25.10+
- CVE-2026-42504 (stdlib, CVSS 7.5) — fix: Go 1.25.11+
- CVE-2026-33814 (stdlib, CVSS 7.5) — fix: Go 1.25.10+
- CVE-2026-33811 (stdlib, CVSS 7.5) — fix: Go 1.25.10+
- CVE-2026-39820 (stdlib, CVSS 7.5) — fix: Go 1.25.10+
- CVE-2026-27145 (stdlib, CVSS 7.5) — fix: Go 1.25.11+

### Fixed by Base Image Rebuild (7 CVEs)
Runtime uses ubi9/ubi-minimal:latest — rebuild picks up patched RPMs:
- CVE-2026-45447 (openssl-libs, CVSS 8.1) — fix: 1:3.5.5-4.el9_8
- CVE-2026-42009 (gnutls, CVSS 7.5) — fix: 0:3.8.10-4.el9_8
- CVE-2026-33846 (gnutls, CVSS 7.5) — fix: 0:3.8.10-4.el9_8
- CVE-2026-33845 (gnutls, CVSS 7.5) — fix: 0:3.8.10-4.el9_8
- CVE-2026-42010 (gnutls, CVSS 7.1) — fix: 0:3.8.10-4.el9_8
- CVE-2026-4878 (libcap, CVSS 6.7) — fix: 0:2.48-10.el9_8.1
- CVE-2026-40356 (krb5-libs, CVSS 5.9) — fix: 0:1.21.1-10.el9_8

### No Fix Available (2 CVEs)
- CVE-2026-58016 (glib2, CVSS 7.5) — no upstream fix
- CVE-2026-54369 (libacl, CVSS 7.1) — no upstream fix

### Security Bug — Manual Fix Required
- [ROSAENG-61334](https://redhat.atlassian.net/browse/ROSAENG-61334): Global dispatcher mutex + unbounded body read enables fail-open bypass (CVSS 7.1)
  - Files: pkg/dispatcher/dispatcher.go, pkg/webhooks/utils/utils.go
  - Action: Remove global mutex, add http.MaxBytesReader, add server timeouts

[About Project Darkstar](https://source.redhat.com/departments/products_and_global_engineering/hybridplatforms/hybrid_platforms_blog/introducing_darkstar_an_experiment_in_ai_assisted_cve_remediation_for_rosa)

[PSHP-545]: https://redhat.atlassian.net/browse/PSHP-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61334]: https://redhat.atlassian.net/browse/ROSAENG-61334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ