### PR TITLE
fix: Remove hardcoded UID from HCP webhook deployment

### DIFF
--- a/build/resources.go
+++ b/build/resources.go
@@ -486,7 +486,6 @@ func createPackagedDeployment(replicas int32, phase string) *appsv1.Deployment {
 								AllowPrivilegeEscalation: pointer.Bool(false),
 								ReadOnlyRootFilesystem:   pointer.Bool(true),
 								RunAsNonRoot:             pointer.Bool(true),
-								RunAsUser:                pointer.Int64(1001),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},

--- a/config/package/resources.yaml.gotmpl
+++ b/config/package/resources.yaml.gotmpl
@@ -124,7 +124,6 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
           seccompProfile:
             type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary

Hotfix to remove the hardcoded `runAsUser: 1001` from the HCP validating-webhook deployment.

The fixed UID is outside the namespace UID range allowed by the `restricted-v2` SCC, causing webhook pods to be rejected and the deployment to have 0 available replicas.

More context: https://redhat-internal.slack.com/archives/C0A8S4L99C2/p1784697684486109?thread_ts=1784697591.159769&cid=C0A8S4L99C2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened runtime security for the validation webhook by disabling privilege escalation, enforcing a read-only root filesystem, and requiring non-root execution.
  * Removed the fixed user ID requirement while retaining non-root enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->