### PR TITLE
[Project Darkstar] ROSAENG-63302: Remediate 2 Go stdlib CVEs in managed-cluster-validating-webhooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/managed-cluster-validating-webhooks
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
## [Project Darkstar] [ROSAENG-63302](https://redhat.atlassian.net/browse/ROSAENG-63302): Remediate CVEs in managed-cluster-validating-webhooks

### Changes
- Add `toolchain go1.26.5` to go.mod (fixes Go stdlib CVEs)

### Fixed — Go stdlib (2 CVEs)
- CVE-2026-39822 (stdlib, CVSS 7.5) — fix: Go 1.26.5+
- CVE-2026-42505 (stdlib, CVSS 5.3) — fix: Go 1.26.5+

### No Fix Available
- 58 RPM-level CVEs (curl-minimal, glib2, libarchive, libxml2, coreutils-single) — no upstream fix
- 5 additional CVEs fixable via base image rebuild at build pipeline level

Note: Prior Darkstar PR #601 was closed unmerged — this PR supersedes it.

> **FedRAMP SLA**: Critical/Important CVEs must be remediated within 30 days of detection.

[About Project Darkstar](https://source.redhat.com/departments/products_and_global_engineering/hybridplatforms/hybrid_platforms_blog/introducing_darkstar_an_experiment_in_ai_assisted_cve_remediation_for_rosa)

[ROSAENG-63302]: https://redhat.atlassian.net/browse/ROSAENG-63302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.26.5 while retaining compatibility with Go 1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->