### PR TITLE
Fix : [ROSAENG-61334] fail-open bypass via dispatcher mutex and unbounded body read

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,7 +95,10 @@ func main() {
 	}
 
 	server := &http.Server{
-		Addr: net.JoinHostPort(*listenAddress, *listenPort),
+		Addr:              net.JoinHostPort(*listenAddress, *listenPort),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
 	}
 	if *useTLS {
 		cafile, err := os.ReadFile(*caCert)

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -15,7 +15,7 @@ import (
 
 var log = logf.Log.WithName("dispatcher")
 
-const maxBodyBytes = 1 << 20 // 1 MiB
+const maxBodyBytes = 3 * 1024 * 1024 // 3 MiB, matches kube-apiserver MaxRequestBodyBytes default
 
 // Dispatcher struct
 type Dispatcher struct {

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -16,10 +15,11 @@ import (
 
 var log = logf.Log.WithName("dispatcher")
 
+const maxBodyBytes = 1 << 20 // 1 MiB
+
 // Dispatcher struct
 type Dispatcher struct {
 	hooks *map[string]webhooks.WebhookFactory // uri -> hookfactory
-	mu    sync.Mutex
 }
 
 // NewDispatcher new dispatcher
@@ -41,8 +41,7 @@ func NewDispatcher(hooks webhooks.RegisteredWebhooks) *Dispatcher {
 // request, or some internal problem) it is appropriate to use the HTTP status
 // code to communicate.
 func (d *Dispatcher) HandleRequest(w http.ResponseWriter, r *http.Request) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 	log.V(1).Info("Handling request", "request", r.RequestURI)
 	url, err := url.Parse(r.RequestURI)
 	if err != nil {

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -2,12 +2,14 @@ package dispatcher
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -39,6 +41,18 @@ func (f *fakeWebhook) SyncSetLabelSelector() metav1.LabelSelector { return metav
 func (f *fakeWebhook) ClassicEnabled() bool                       { return true }
 func (f *fakeWebhook) HypershiftEnabled() bool                    { return false }
 
+type blockingWebhook struct {
+	fakeWebhook
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingWebhook) Authorized(_ admissionctl.Request) admissionctl.Response {
+	b.entered <- struct{}{}
+	<-b.release
+	return admissionctl.Allowed("ok")
+}
+
 func newTestDispatcher() *Dispatcher {
 	hooks := webhooks.RegisteredWebhooks{
 		"test-validation": func() webhooks.Webhook { return &fakeWebhook{} },
@@ -46,7 +60,8 @@ func newTestDispatcher() *Dispatcher {
 	return NewDispatcher(hooks)
 }
 
-func validAdmissionReviewBody() []byte {
+func validAdmissionReviewBody(t testing.TB) []byte {
+	t.Helper()
 	ar := admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{
 			UID: types.UID("test-uid"),
@@ -63,7 +78,10 @@ func validAdmissionReviewBody() []byte {
 			Operation: admissionv1.Create,
 		},
 	}
-	b, _ := json.Marshal(ar)
+	b, err := json.Marshal(ar)
+	if err != nil {
+		t.Fatalf("failed to marshal AdmissionReview: %v", err)
+	}
 	return b
 }
 
@@ -75,7 +93,7 @@ func TestHandleRequest_OversizedBody(t *testing.T) {
 		oversized[i] = 'A'
 	}
 
-	req := httptest.NewRequest("POST", "/test-hook", bytes.NewReader(oversized))
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/test-hook", bytes.NewReader(oversized))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -89,8 +107,8 @@ func TestHandleRequest_OversizedBody(t *testing.T) {
 func TestHandleRequest_ValidRequest(t *testing.T) {
 	d := newTestDispatcher()
 
-	body := validAdmissionReviewBody()
-	req := httptest.NewRequest("POST", "/test-hook", bytes.NewReader(body))
+	body := validAdmissionReviewBody(t)
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/test-hook", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -112,7 +130,7 @@ func TestHandleRequest_ValidRequest(t *testing.T) {
 func TestHandleRequest_UnknownURI(t *testing.T) {
 	d := newTestDispatcher()
 
-	req := httptest.NewRequest("POST", "/unknown-hook", strings.NewReader("{}"))
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/unknown-hook", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -124,30 +142,38 @@ func TestHandleRequest_UnknownURI(t *testing.T) {
 }
 
 func TestHandleRequest_ConcurrentRequests(t *testing.T) {
-	d := newTestDispatcher()
-	body := validAdmissionReviewBody()
+	bw := &blockingWebhook{
+		entered: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	hooks := webhooks.RegisteredWebhooks{
+		"test-validation": func() webhooks.Webhook { return bw },
+	}
+	d := NewDispatcher(hooks)
+	body := validAdmissionReviewBody(t)
 
-	const concurrency = 20
 	var wg sync.WaitGroup
-	wg.Add(concurrency)
-	errors := make(chan string, concurrency)
-
-	for i := 0; i < concurrency; i++ {
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
 		go func() {
 			defer wg.Done()
-			req := httptest.NewRequest("POST", "/test-hook", bytes.NewReader(body))
+			req := httptest.NewRequestWithContext(context.Background(), "POST", "/test-hook", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 			d.HandleRequest(w, req)
-			if w.Code != http.StatusOK {
-				errors <- "expected 200"
-			}
 		}()
 	}
 
-	wg.Wait()
-	close(errors)
-	for e := range errors {
-		t.Error(e)
+	// Both goroutines should enter Authorized concurrently.
+	// With a global mutex this would deadlock on the second send.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-bw.entered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for concurrent handler entry — requests may be serialized")
+		}
 	}
+
+	close(bw.release)
+	wg.Wait()
 }

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -1,0 +1,153 @@
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	admissionctl "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/openshift/managed-cluster-validating-webhooks/pkg/webhooks"
+)
+
+type fakeWebhook struct{}
+
+func (f *fakeWebhook) Authorized(_ admissionctl.Request) admissionctl.Response {
+	return admissionctl.Allowed("ok")
+}
+func (f *fakeWebhook) GetURI() string                                  { return "/test-hook" }
+func (f *fakeWebhook) Validate(_ admissionctl.Request) bool            { return true }
+func (f *fakeWebhook) Name() string                                    { return "test-validation" }
+func (f *fakeWebhook) FailurePolicy() admissionregv1.FailurePolicyType { return admissionregv1.Ignore }
+func (f *fakeWebhook) MatchPolicy() admissionregv1.MatchPolicyType     { return admissionregv1.Equivalent }
+func (f *fakeWebhook) Rules() []admissionregv1.RuleWithOperations      { return nil }
+func (f *fakeWebhook) ObjectSelector() *metav1.LabelSelector           { return nil }
+func (f *fakeWebhook) SideEffects() admissionregv1.SideEffectClass {
+	return admissionregv1.SideEffectClassNone
+}
+func (f *fakeWebhook) TimeoutSeconds() int32                      { return 2 }
+func (f *fakeWebhook) Doc() string                                { return "" }
+func (f *fakeWebhook) SyncSetLabelSelector() metav1.LabelSelector { return metav1.LabelSelector{} }
+func (f *fakeWebhook) ClassicEnabled() bool                       { return true }
+func (f *fakeWebhook) HypershiftEnabled() bool                    { return false }
+
+func newTestDispatcher() *Dispatcher {
+	hooks := webhooks.RegisteredWebhooks{
+		"test-validation": func() webhooks.Webhook { return &fakeWebhook{} },
+	}
+	return NewDispatcher(hooks)
+}
+
+func validAdmissionReviewBody() []byte {
+	ar := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			UID: types.UID("test-uid"),
+			Kind: metav1.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Namespace",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "namespaces",
+			},
+			Operation: admissionv1.Create,
+		},
+	}
+	b, _ := json.Marshal(ar)
+	return b
+}
+
+func TestHandleRequest_OversizedBody(t *testing.T) {
+	d := newTestDispatcher()
+
+	oversized := make([]byte, maxBodyBytes+1)
+	for i := range oversized {
+		oversized[i] = 'A'
+	}
+
+	req := httptest.NewRequest("POST", "/test-hook", bytes.NewReader(oversized))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	d.HandleRequest(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d for oversized body, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestHandleRequest_ValidRequest(t *testing.T) {
+	d := newTestDispatcher()
+
+	body := validAdmissionReviewBody()
+	req := httptest.NewRequest("POST", "/test-hook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	d.HandleRequest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var review admissionv1.AdmissionReview
+	if err := json.Unmarshal(w.Body.Bytes(), &review); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if !review.Response.Allowed {
+		t.Error("expected request to be allowed")
+	}
+}
+
+func TestHandleRequest_UnknownURI(t *testing.T) {
+	d := newTestDispatcher()
+
+	req := httptest.NewRequest("POST", "/unknown-hook", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	d.HandleRequest(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status %d for unknown URI, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestHandleRequest_ConcurrentRequests(t *testing.T) {
+	d := newTestDispatcher()
+	body := validAdmissionReviewBody()
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	errors := make(chan string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest("POST", "/test-hook", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			d.HandleRequest(w, req)
+			if w.Code != http.StatusOK {
+				errors <- "expected 200"
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+	for e := range errors {
+		t.Error(e)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [ROSAENG-61334](https://issues.redhat.com/browse/ROSAENG-61334) — global dispatcher mutex + unbounded body read enables fail-open bypass of all validating webhooks.

- **Remove global mutex**: `Dispatcher.HandleRequest` held a process-wide `sync.Mutex` that serialized all admission requests. Since the `hooks` map is read-only after initialization and `hook()` returns fresh instances, no synchronization is needed. The serial bottleneck allowed a single slow/malicious request to block all others past the 2s webhook timeout, triggering `failurePolicy: Ignore` bypass.
- **Add request body size limit**: Wrap `r.Body` with `http.MaxBytesReader` (1 MiB) to reject oversized payloads that could hold connections open via unbounded `io.ReadAll`.
- **Add HTTP server timeouts**: Set `ReadHeaderTimeout` (5s), `ReadTimeout` (10s), and `WriteTimeout` (10s) on `http.Server` to prevent slowloris-style connection holding.

## Changed files

- `pkg/dispatcher/dispatcher.go` — remove mutex, add `MaxBytesReader`
- `cmd/main.go` — add server timeouts
- `pkg/dispatcher/dispatcher_test.go` — new tests for oversized body rejection, valid requests, unknown URIs, and concurrent request handling

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all existing + 4 new dispatcher tests)
- [x] `make vet` passes
- [ ] Verify in staging that admission requests are processed concurrently
- [ ] Verify oversized request bodies (>1 MiB) are rejected with HTTP 400
- [ ] Verify slow clients are disconnected after server timeout

## References

- JIRA: [ROSAENG-61334](https://issues.redhat.com/browse/ROSAENG-61334)
- CWEs: CWE-770 (Allocation of Resources Without Limits), CWE-667 (Improper Locking), CWE-400 (Uncontrolled Resource Consumption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROSAENG-61334]: https://redhat.atlassian.net/browse/ROSAENG-61334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-61334]: https://redhat.atlassian.net/browse/ROSAENG-61334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protection against request bodies larger than 3 MiB.
  * Added HTTP server timeouts to improve handling of slow or incomplete requests.

* **Bug Fixes**
  * Improved request processing reliability during concurrent traffic.
  * Requests to unknown endpoints now receive consistent responses.

* **Tests**
  * Expanded coverage for valid requests, oversized payloads, unknown endpoints, and concurrent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->