### PR TITLE
ROSAENG-63302: Add toolchain go1.26.5 to remediate Go stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/managed-cluster-validating-webhooks
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
## Summary
- Add `toolchain go1.26.5` directive to `go.mod` to fix 2 Go stdlib CVEs identified in FedRAMP compliance scan
- Supersedes draft PR #611

### Fixed — Go stdlib (2 CVEs)
| CVE | Severity | CVSS | Fixed In |
|-----|----------|------|----------|
| CVE-2026-39822 | Important | 7.5 | Go 1.26.5+ |
| CVE-2026-42505 | Moderate | 5.3 | Go 1.26.5+ |

### Not fixable in this PR
- 58 RPM-level CVEs (curl-minimal, glib2, libarchive, libxml2, etc.) — no upstream fix available
- 5 additional CVEs fixable via base image rebuild at build pipeline level (glib2, libacl, glibc, libsolv)

> **FedRAMP SLA**: Critical/Important CVEs must be remediated within 30 days of detection.

[ROSAENG-63302]: https://redhat.atlassian.net/browse/ROSAENG-63302

## Test plan
- [ ] Verify `make test` passes
- [ ] Verify `make build` succeeds with Go 1.26.5 toolchain
- [ ] Confirm CVE-2026-39822 and CVE-2026-42505 are resolved in rebuilt image scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.26.5.
  * Improved build, deployment, validation, and test scripts to handle file and directory paths more reliably.
  * Increased robustness when checking container images and processing build results, particularly in environments with spaces or special characters in paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->