### PR TITLE
Update prefetch-dependencies-oci-ta to trusted version 0.9.0

### DIFF
--- a/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml
@@ -190,7 +190,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-e2e-push.yaml
@@ -180,7 +180,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-pull-request.yaml
@@ -187,7 +187,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/managed-cluster-validating-webhooks-push.yaml
+++ b/.tekton/managed-cluster-validating-webhooks-push.yaml
@@ -184,7 +184,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Update `prefetch-dependencies-oci-ta` task bundle from `0.4.1` to `0.9.0` in all 4 Tekton pipeline files
- The old `0.4.1` digest was removed from Konflux's trusted task catalog, causing Enterprise Contract checks to fail on all PRs (including #613)

### Files updated
- `.tekton/managed-cluster-validating-webhooks-pull-request.yaml`
- `.tekton/managed-cluster-validating-webhooks-push.yaml`
- `.tekton/managed-cluster-validating-webhooks-e2e-pull-request.yaml`
- `.tekton/managed-cluster-validating-webhooks-e2e-push.yaml`

### Error this fixes
```
Required task "prefetch-dependencies-oci-ta" is required and present but not from a trusted task
```

## Test plan
- [ ] Verify Konflux Enterprise Contract checks pass on this PR
- [ ] Verify Konflux build pipelines still complete successfully
- [ ] Confirm `prefetch-dependencies` task runs without parameter compatibility issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency-prefetching task bundle used by validation workflows to version 0.9.0.
  * Refreshed the pinned integrity references for consistent and reliable workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->