### PR TITLE
ROSAENG-63302: Add toolchain go1.26.5 to remediate Go stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/managed-cluster-validating-webhooks
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
## Summary
- Add `toolchain go1.26.5` directive to `go.mod` to fix Go stdlib CVEs (CVE-2026-39822, CVE-2026-42505)
- Rebased onto current `master` so Konflux picks up #616 (boilerplate `master` / prefetch 0.9.0)

Supersedes https://github.com/openshift/managed-cluster-validating-webhooks/pull/613 — that branch was still on the pre-#616 PKO boilerplate pin (`5b58d5f` → prefetch 0.3) and failed EC with `trusted_task` / `deny_rule`.

[ROSAENG-63302]: https://redhat.atlassian.net/browse/ROSAENG-63302

## Test plan
- [ ] Konflux EC green (main / e2e / pko / pr group)
- [ ] `make test` / `make build` with Go 1.26.5 toolchain
- [ ] Confirm CVE-2026-39822 and CVE-2026-42505 cleared in rebuilt image scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->