### PR TITLE
[ROSAENG-61186] - fix: Allow OSC operator to manage MachineConfigs

### DIFF
--- a/pkg/webhooks/regularuser/common/regularuser.go
+++ b/pkg/webhooks/regularuser/common/regularuser.go
@@ -54,6 +54,15 @@ var (
 		"system:serviceaccount:openshift-cluster-node-tuning-operator:cluster-node-tuning-operator",
 		"system:serviceaccount:openshift-machine-config-operator:machine-config-controller",
 		"system:admin",
+		// The OpenShift Sandboxed Containers operator creates/modifies MachineConfig
+		// resources when a KataConfig is reconciled. Its CSV currently runs the
+		// controller as the `default` ServiceAccount in the fixed
+		// `openshift-sandboxed-containers-operator` namespace, so this entry matches
+		// the complete Kubernetes identity (namespace + ServiceAccount) and does not
+		// wildcard other namespaces or service accounts. A future dedicated OSC
+		// ServiceAccount may coexist with this entry; remove it only once no
+		// supported OSC version still relies on this identity.
+		"system:serviceaccount:openshift-sandboxed-containers-operator:default",
 	}
 	ceeGroup = "system:serviceaccounts:openshift-backplane-cee"
 

--- a/pkg/webhooks/regularuser/common/regularuser_test.go
+++ b/pkg/webhooks/regularuser/common/regularuser_test.go
@@ -272,6 +272,44 @@ func TestMachineConfig(t *testing.T) {
 			operation:       admissionv1.Create,
 			shouldBeAllowed: false,
 		},
+		{
+			// OSC operator uses the `default` SA in the fixed
+			// openshift-sandboxed-containers-operator namespace (ROSAENG-61186).
+			testID:          "machineconfig-osc-serviceaccount",
+			targetResource:  "machineconfigs",
+			targetKind:      "MachineConfig",
+			targetVersion:   "v1",
+			targetGroup:     "machineconfiguration.openshift.io",
+			username:        "system:serviceaccount:openshift-sandboxed-containers-operator:default",
+			userGroups:      []string{"system:authenticated", "system:serviceaccounts", "system:serviceaccounts:openshift-sandboxed-containers-operator"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: true,
+		},
+		{
+			// The exception is scoped to the exact identity: the same `default` SA
+			// in a different namespace must remain denied.
+			testID:          "machineconfig-osc-serviceaccount-wrong-namespace",
+			targetResource:  "machineconfigs",
+			targetKind:      "MachineConfig",
+			targetVersion:   "v1",
+			targetGroup:     "machineconfiguration.openshift.io",
+			username:        "system:serviceaccount:some-other-namespace:default",
+			userGroups:      []string{"system:authenticated", "system:serviceaccounts", "system:serviceaccounts:some-other-namespace"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
+		{
+			// A different SA within the OSC namespace must remain denied.
+			testID:          "machineconfig-osc-serviceaccount-wrong-sa",
+			targetResource:  "machineconfigs",
+			targetKind:      "MachineConfig",
+			targetVersion:   "v1",
+			targetGroup:     "machineconfiguration.openshift.io",
+			username:        "system:serviceaccount:openshift-sandboxed-containers-operator:some-other-sa",
+			userGroups:      []string{"system:authenticated", "system:serviceaccounts", "system:serviceaccounts:openshift-sandboxed-containers-operator"},
+			operation:       admissionv1.Create,
+			shouldBeAllowed: false,
+		},
 	}
 	runRegularuserTests(t, tests)
 }


### PR DESCRIPTION
## What

Allowlist the OSC controller identity below in the MCVW MachineConfig authorization.
```
system:serviceaccount:openshift-sandboxed-containers-operator:default
```

## Why
- When reconciling a KataConfig, the OpenShift Sandboxed Containers operator needs to create and modify MachineConfig resources.

- The OSC controller currently runs as the `default` ServiceAccount in the fixed `openshift-sandboxed-containers-operator` namespace. Since this identity was not included in MCVW's trusted MachineConfig users, the requests were rejected by `regular-user-validation.managed.openshift.io`.

- The exception matches the exact Kubernetes identity (`namespace + ServiceAccount`), so it does not allow `default` ServiceAccounts from other namespaces or **other ServiceAccounts in the OSC namespace**.

- OSD-GCP is the reported scenario for this issue. The MachineConfig authorization path is shared across applicable Classic managed clusters, with no provider-specific logic introduced by this change.

## Local E2E Validation
### Test env with a staging OSD GCP WIF cluster
```
Cluster: sa-gcpw/2ri1e9iikta9fap8lb3vqftcffl4ipup
Version: 4.22.3
Provider: GCP WIF
Test workload: registry.redhat.io/openshift4/ose-cli-rhel9:v4.22
```
**Note:**
- Hive `SyncSe`t was paused while testing the custom MCVW image.
- Manually created temporary `ClusterRole/ClusterRoleBinding` granting the minimum required MachineConfig permissions.
- To simulate the same identity used by the `OSC controller` without installing the full OSC stack, I manually created the namespace `openshift-sandboxed-containers-operator` and temporary `ose-cli` workload

### Before - Using existing MCVW image
```
oc get pod -n openshift-sandboxed-containers-operator

NAME                       READY   STATUS    RESTARTS   AGE
rosaeng-61186-validation   1/1     Running   0          12s

bp-elevate exec \
  -n openshift-sandboxed-containers-operator \
  rosaeng-61186-validation \
  -- oc patch machineconfig "$TEST_MC" \
  --type=merge \
  --patch='{"metadata":{"annotations":{"rosaeng-61186-validation":"before"}}}' \
  --dry-run=server
Error from server (Forbidden): admission webhook "regular-user-validation.managed.openshift.io" denied the request: Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support
command terminated with exit code 1
ERRO[0004] exit status 1
```
**Note:** With the existing MCVW image, the OSC operator's default ServiceAccount in `openshift-sandboxed-containers-operator` was denied from modifying MachineConfig by MCVW

### After - Build a new image with this PR
- Deployed the new built MCVW image
```
oc get pods \
  -n openshift-validation-webhook \
  -o jsonpath='{range .items[*]}{.metadata.name}{"  "}{.spec.containers[0].image}{"\n"}{end}'

validation-webhook-2jcg4  quay.io/sbai_openshift/managed-cluster-validating-webhooks:rosaeng-61186-8e5df14
```
- dry-run the `MachineConfig` Patch
```
bp-elevate exec \
  -n openshift-sandboxed-containers-operator \
  rosaeng-61186-validation \
  -- /bin/bash -c "
    SERVER=\"https://\${KUBERNETES_SERVICE_HOST}:\${KUBERNETES_SERVICE_PORT_HTTPS}\"
    TOKEN=\"\$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\"
    CA=\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\"

    oc \
      --server=\"\${SERVER}\" \
      --token=\"\${TOKEN}\" \
      --certificate-authority=\"\${CA}\" \
      patch machineconfig '${TEST_MC}' \
      --type=merge \
      --patch='{\"metadata\":{\"annotations\":{\"rosaeng-61186-validation\":\"after\"}}}' \
      --dry-run=server
  "
machineconfig.machineconfiguration.openshift.io/00-master patched
```
**Note:** PR-built image allowed the same server-side dry-run request, confirming the intended MCVW authorization change

## For reviewers

- A **dedicated OSC ServiceAccount** remains a cleaner long-term identity model and can be handled separately upstream.
- More Context: https://redhat-internal.slack.com/archives/CCX9DB894/p1787611543919009?thread_ts=1782949457.002039&cid=CCX9DB894